### PR TITLE
Restore CLI integrations in the Mac App Store app

### DIFF
--- a/.github/workflows/app-store-upload.yml
+++ b/.github/workflows/app-store-upload.yml
@@ -1,0 +1,150 @@
+name: App Store Upload
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: Draft GitHub release containing the signed Mac App Store package
+        required: true
+        type: string
+      package_sha256:
+        description: SHA-256 of the signed package
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: app-store-upload
+  cancel-in-progress: false
+
+jobs:
+  upload:
+    name: Validate and upload signed package
+    runs-on: macos-latest
+    timeout-minutes: 60
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      APPLE_ID: ${{ secrets.APPLE_ID }}
+      APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD || secrets.APPLE_PASSWORD }}
+    steps:
+      - name: Checkout upload workflow revision
+        uses: actions/checkout@v6
+
+      - name: Require upload credentials
+        shell: bash
+        run: |
+          set -euo pipefail
+          missing=()
+          [ -n "$APPLE_ID" ] || missing+=("APPLE_ID")
+          [ -n "$APPLE_APP_SPECIFIC_PASSWORD" ] || missing+=("APPLE_APP_SPECIFIC_PASSWORD")
+          if [ ${#missing[@]} -gt 0 ]; then
+            printf '::error::Missing repository secret: %s\n' "${missing[@]}" >&2
+            exit 1
+          fi
+
+      - name: Download signed package
+        shell: bash
+        env:
+          RELEASE_TAG: ${{ inputs.release_tag }}
+        run: |
+          set -euo pipefail
+          mkdir delivery
+          gh release download "$RELEASE_TAG" \
+            --repo "$GITHUB_REPOSITORY" \
+            --pattern '*.pkg' \
+            --dir delivery
+
+          shopt -s nullglob
+          packages=(delivery/*.pkg)
+          if [ ${#packages[@]} -ne 1 ]; then
+            echo "::error::Expected exactly one .pkg asset, found ${#packages[@]}." >&2
+            exit 1
+          fi
+          echo "PACKAGE_PATH=${packages[0]}" >> "$GITHUB_ENV"
+
+      - name: Verify package identity and checksum
+        shell: bash
+        env:
+          EXPECTED_SHA256: ${{ inputs.package_sha256 }}
+        run: |
+          set -euo pipefail
+          actual_sha256=$(shasum -a 256 "$PACKAGE_PATH" | awk '{print $1}')
+          if [ "$actual_sha256" != "$EXPECTED_SHA256" ]; then
+            echo "::error::Package checksum mismatch." >&2
+            exit 1
+          fi
+
+          signature=$(pkgutil --check-signature "$PACKAGE_PATH")
+          printf '%s\n' "$signature"
+          if ! grep -q '3rd Party Mac Developer Installer' <<<"$signature"; then
+            echo "::error::Package is not signed for Mac App Store distribution." >&2
+            exit 1
+          fi
+          echo "Verified signed package SHA-256: $actual_sha256"
+
+      - name: Discover App Store Connect provider
+        id: provider
+        shell: bash
+        run: |
+          set -euo pipefail
+          xcrun altool --list-providers \
+            --username "$APPLE_ID" \
+            --password @env:APPLE_APP_SPECIFIC_PASSWORD \
+            --output-format json > "$RUNNER_TEMP/providers.json"
+
+          node <<'NODE'
+          const fs = require('fs');
+          const providers = JSON.parse(fs.readFileSync(process.env.RUNNER_TEMP + '/providers.json', 'utf8'));
+          const ids = new Set();
+          function visit(value) {
+            if (!value || typeof value !== 'object') return;
+            if (Array.isArray(value)) {
+              value.forEach(visit);
+              return;
+            }
+            for (const [key, child] of Object.entries(value)) {
+              if (typeof child === 'string' && /^(provider)?public(id|identifier)$/i.test(key.replace(/[^a-z]/gi, ''))) {
+                ids.add(child);
+              }
+              visit(child);
+            }
+          }
+          visit(providers);
+          if (ids.size !== 1) {
+            throw new Error(`Expected one App Store Connect provider public ID; found ${ids.size}.`);
+          }
+          const [providerId] = ids;
+          fs.appendFileSync(process.env.GITHUB_OUTPUT, `public_id=${providerId}\n`);
+          console.log('Authenticated to one App Store Connect provider.');
+          NODE
+
+      - name: Validate package with App Store Connect
+        shell: bash
+        env:
+          PROVIDER_PUBLIC_ID: ${{ steps.provider.outputs.public_id }}
+        run: |
+          set -euo pipefail
+          xcrun altool --validate-app "$PACKAGE_PATH" \
+            --username "$APPLE_ID" \
+            --password @env:APPLE_APP_SPECIFIC_PASSWORD \
+            --provider-public-id "$PROVIDER_PUBLIC_ID" \
+            --output-format json
+
+      - name: Upload package to App Store Connect
+        shell: bash
+        env:
+          PROVIDER_PUBLIC_ID: ${{ steps.provider.outputs.public_id }}
+        run: |
+          set -euo pipefail
+          xcrun altool --upload-package "$PACKAGE_PATH" \
+            --username "$APPLE_ID" \
+            --password @env:APPLE_APP_SPECIFIC_PASSWORD \
+            --provider-public-id "$PROVIDER_PUBLIC_ID" \
+            --wait \
+            --output-format json | tee "$RUNNER_TEMP/upload-result.json"
+
+          echo '### Mac App Store delivery' >> "$GITHUB_STEP_SUMMARY"
+          echo '' >> "$GITHUB_STEP_SUMMARY"
+          echo "Uploaded the checksum-verified package from \`${{ inputs.release_tag }}\`." >> "$GITHUB_STEP_SUMMARY"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Notarization no longer skips silently: missing credentials, a non-Developer ID certificate, or a failed submission now fail the release build.
 - Release notes now list the real `markuprplus-*` artifact names and no longer overwrite the curated changelog.
 
+## 3.1.0 - 2026-08-30
+
+### Added
+
+- Restored Codex CLI, Claude Code CLI, OpenCode, Cursor Agent CLI, Qwen Code, Goose, Amp, Kiro CLI, and Aider report providers in the Mac App Store app through an optional local companion.
+- Added `markuprx bridge` lifecycle commands for secure per-user installation, status, pairing-token rotation, restart, and removal.
+- Added a Store-only setup panel with copyable commands, Keychain-backed pairing, connection diagnostics, and live provider readiness.
+
+### Security
+
+- The companion accepts only a versioned, path-free report protocol on authenticated IPv4 loopback and never accepts arbitrary executables, arguments, shell text, environment variables, working directories, or filesystem paths.
+- Bridge requests have strict body, screenshot, transcript, timeout, and concurrency limits. Pairing tokens are generated from 32 random bytes and stored with owner-only permissions and in macOS Keychain.
+
+### Changed
+
+- Bumped the Mac App Store bundle to version 3.1.0, build 3, with updated privacy disclosures and App Review instructions.
+
 ## 3.0.0 - 2026-08-15
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -134,11 +134,15 @@ The sandboxed Mac App Store app can use AI command-line tools already installed 
 Install and pair it from a Terminal:
 
 ```bash
-npm install -g markuprx@latest
+npm install -g https://github.com/hashfunction/MarkuprPlus/releases/download/v3.1.0/markuprx-3.1.0.tgz
 markuprx bridge install     # installs and starts a per-user LaunchAgent
 markuprx bridge token       # paste this value in Settings → Advanced
 markuprx bridge status
 ```
+
+The versioned package is published with the official GitHub release so the
+companion used by the Store app is reproducible and remains available even
+without an npm registry account.
 
 The service listens only on `127.0.0.1:49647`, requires its random pairing token for every provider request, and accepts a fixed structured-report protocol rather than shell text. The App Store app does not run shell commands or launch external tools; the separately installed companion invokes only the provider selected in Settings.
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 <p align="center">
   <a href="https://github.com/hashfunction/MarkuprPlus/actions/workflows/ci.yml?query=branch%3Amain"><img src="https://github.com/hashfunction/MarkuprPlus/actions/workflows/ci.yml/badge.svg?branch=main" alt="CI status"></a>
   <a href="https://github.com/hashfunction/MarkuprPlus/actions/workflows/deploy-landing.yml?query=branch%3Amain"><img src="https://github.com/hashfunction/MarkuprPlus/actions/workflows/deploy-landing.yml/badge.svg?branch=main" alt="Deployment status"></a>
-  <img src="https://img.shields.io/badge/version-3.0.0-f59e0b?style=flat-square" alt="Version 3.0.0">
+  <img src="https://img.shields.io/badge/version-3.1.0-f59e0b?style=flat-square" alt="Version 3.1.0">
   <img src="https://img.shields.io/badge/macOS%20%7C%20Windows-desktop-lightgrey?style=flat-square" alt="Platforms">
   <img src="https://img.shields.io/badge/transcription-local%20Whisper-4ade80?style=flat-square" alt="Local Whisper transcription">
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue.svg?style=flat-square" alt="License"></a>
@@ -124,19 +124,36 @@ npx --package markuprx markuprx-mcp
 npx markuprx analyze ./recording.mov
 ```
 
-> **Heads up — pre-release.** The npm package is not published yet, so the `npx`
-> forms above will 404 today. Until it lands, build from a source checkout and
-> the same two binaries are available locally:
->
-> ```bash
-> git clone https://github.com/hashfunction/MarkuprPlus.git
-> cd MarkuprPlus && npm install && npm run build
-> node dist/cli/index.mjs analyze ./recording.mov
-> node dist/mcp/index.mjs                     # MCP server over stdio
-> ```
-
 > **Naming:** the product is **MarkuprPlus**; the package and its binaries stay
 > `markuprx` / `markuprx-mcp` for compatibility. `npx markuprplus …` is not a thing.
+
+### Optional companion for Mac App Store CLI integrations
+
+The sandboxed Mac App Store app can use AI command-line tools already installed and signed in on your Mac through the optional MarkuprPlus CLI Bridge. Local Rules, Ollama, LM Studio, and Anthropic API do not require this companion.
+
+Install and pair it from a Terminal:
+
+```bash
+npm install -g markuprx@latest
+markuprx bridge install     # installs and starts a per-user LaunchAgent
+markuprx bridge token       # paste this value in Settings → Advanced
+markuprx bridge status
+```
+
+The service listens only on `127.0.0.1:49647`, requires its random pairing token for every provider request, and accepts a fixed structured-report protocol rather than shell text. The App Store app does not run shell commands or launch external tools; the separately installed companion invokes only the provider selected in Settings.
+
+Lifecycle and recovery commands:
+
+```bash
+markuprx bridge start
+markuprx bridge stop
+markuprx bridge status
+markuprx bridge token
+markuprx bridge rotate-token
+markuprx bridge uninstall
+```
+
+Rotating the token requires pairing again. Uninstall removes the exact LaunchAgent and bridge configuration owned by MarkuprPlus; it does not uninstall your AI CLIs.
 
 ## What Lands in Your Folder
 
@@ -249,6 +266,8 @@ Marked issues are numbered `MX-001…`; items that come from narration alone are
 
 Pick the model that turns a capture into a structured report. MarkuprPlus checks each one **before** you record and shows you what it actually found.
 
+In the Mac App Store app, CLI providers use the optional local companion described above. Direct desktop builds invoke the same adapters inside the app. Both paths preserve Local Rules as the failure-safe report.
+
 | Provider | Kind | What it uses |
 |---|---|---|
 | **Codex CLI** | CLI | Your installed Codex CLI and existing ChatGPT login, in a read-only ephemeral session |
@@ -337,7 +356,7 @@ Full MCP documentation: [README-MCP.md](README-MCP.md).
 ## CLI
 
 ```bash
-npx markuprx analyze ./recording.mov     # once published; see the pre-release note above
+npx markuprx analyze ./recording.mov
 ```
 
 | Command | What it does |

--- a/app-store/metadata/en-US.md
+++ b/app-store/metadata/en-US.md
@@ -12,6 +12,9 @@ Circle the bug. Give your AI the whole story. MarkuprPlus turns each mark and sp
 ## Keywords
 bug report,screen recorder,AI feedback,annotation,transcription,Markdown,QA,code review,screenshot
 
+## What's New in Version 3.1.0
+CLI report integrations are back in the Mac App Store app through an optional local companion. Connect Codex CLI, Claude Code CLI, OpenCode, Cursor Agent, Qwen Code, Goose, Amp, Kiro, or Aider from Advanced Settings. This update also adds secure Keychain pairing, bridge status diagnostics, and stricter report-transport limits. Local Rules remains available with no setup or network connection.
+
 ## Description
 Circle the bug. Give your AI the whole story.
 
@@ -32,6 +35,10 @@ Record microphone narration alongside the screen. On-device Whisper can transcri
 CHOOSE HOW AI HELPS
 
 Use deterministic Local Rules with no model, connect to Ollama or LM Studio on your Mac, or bring an Anthropic API key stored in Keychain. MarkuprPlus uses only the provider you select and still writes a local report if analysis fails.
+
+OPTIONAL CLI WORKFLOWS
+
+Connect Codex CLI, Claude Code CLI, OpenCode, Cursor Agent, Qwen Code, Goose, Amp, Kiro, or Aider through an optional local companion you install separately. The App Store app sends structured report material over an authenticated loopback connection to the companion on your Mac; the companion invokes only the CLI you selected. The App Store app never executes shell commands.
 
 REVIEW BEFORE YOU HAND IT OFF
 

--- a/app-store/privacy-answers.md
+++ b/app-store/privacy-answers.md
@@ -16,12 +16,14 @@ These answers describe the sandboxed Mac App Store build. Reconfirm them against
 
 Recordings, narration, screenshots, transcripts, reports, preferences, and API keys are processed and stored on the user's Mac. When a user explicitly selects Anthropic API analysis, the app sends the transcript and selected screenshots directly to Anthropic using the user's own key; Trieflow LLC does not receive that material. The App Store label therefore conservatively discloses Photos or Videos and Other User Content as Data Linked to You and used for App Functionality. OpenAI audio transcription currently has no abuse-monitoring or application-state retention according to OpenAI's endpoint-specific data-controls documentation, so Audio Data is not listed as collected under Apple's current definition. Reconfirm both providers' retention policies before each submission.
 
+When a user explicitly pairs the optional local CLI companion, the app sends transcript text and selected screenshots over an authenticated IPv4 loopback connection to `127.0.0.1:49647`. The companion runs on the same Mac and invokes only the CLI provider selected by the user. That CLI may contact its own provider under the user's existing account and the provider's privacy terms. Neither the app nor the companion sends this content or its random pairing token to Trieflow LLC. The Mac App Store app does not execute shell commands or install the companion.
+
 ## Permissions
 
 - Screen Recording: required to capture the user-selected window, region, or display.
 - Microphone: optional narration recorded only during a user-started capture.
 - User-selected file read/write: used for exports chosen through system dialogs.
-- Outgoing network: optional provider requests, local model endpoints, model data downloads, and support links.
+- Outgoing network: optional provider requests, fixed loopback connections to local model endpoints and the optional companion, model data downloads, and support links.
 - Camera, Contacts, Calendars, Photos, Location, Bluetooth, HomeKit, Health, and advertising identifiers: not used.
 
 ## Age Rating

--- a/app-store/review-notes.md
+++ b/app-store/review-notes.md
@@ -1,22 +1,31 @@
-# App Review Notes — MarkuprPlus 3.0.0
+# App Review Notes — MarkuprPlus 3.1.0
 
 MarkuprPlus is a menu bar app for creating structured visual-feedback reports for AI coding agents. It does not require an account and has no developer-operated telemetry.
 
-## Review walkthrough
+## Review walkthrough — Local Rules (no companion required)
 
 1. Launch MarkuprPlus and complete the short onboarding flow.
 2. Grant Screen Recording permission when macOS requests it. This permission is required only to capture the window, region, or display the reviewer explicitly selects.
 3. Grant Microphone permission to include narration, or continue without narration.
-4. Press Command-Shift-F and choose a window, region, or display.
-5. Use the visible Draw control to mark a finding while interacting with the selected source.
-6. Press Command-Shift-F again to stop. MarkuprPlus writes a local report and opens the review surface.
-7. Edit or reorder findings, preview the Markdown, and export or copy the report path.
+4. Open Settings → Advanced and select Local Rules. It is ready immediately and requires no account, companion, model, credential, or network connection.
+5. Press Command-Shift-F and choose a window, region, or display.
+6. Use the visible Draw control to mark a finding while interacting with the selected source.
+7. Press Command-Shift-F again to stop. MarkuprPlus writes a local report and opens the review surface.
+8. Edit or reorder findings, preview the Markdown, and export or copy the report path.
+
+## Optional CLI Bridge
+
+Version 3.1.0 restores optional compatibility with Codex CLI, Claude Code CLI, OpenCode, Cursor Agent, Qwen Code, Goose, Amp, Kiro, and Aider. This feature is not required to complete the review walkthrough above.
+
+To test it, install the public npm package in Terminal with `npm install -g markuprx@latest`, run `markuprx bridge install`, then run `markuprx bridge token`. In MarkuprPlus, open Settings → Advanced, paste that token into CLI Integrations, and choose any compatible CLI already installed and signed in for the reviewer. `markuprx bridge status` reports whether the per-user companion is running.
+
+The companion binds only to IPv4 loopback at `127.0.0.1:49647`, requires bearer-token authentication, and accepts only a fixed structured report protocol. The Mac App Store app does not execute external command-line tools inside its sandbox, does not accept or send arbitrary shell commands, and does not install the companion. The separately installed companion invokes only the provider explicitly selected by the user.
 
 ## AI and network behavior
 
 Local Rules is always available and requires no model or network connection. On-device Whisper transcription runs locally after a model is installed. Ollama and LM Studio use fixed loopback endpoints. Anthropic API analysis is optional, requires the reviewer's own API key, and sends content only when that provider is explicitly selected. The key is stored in macOS Keychain.
 
-The sandboxed Mac App Store build does not execute external coding-agent command-line tools and does not contain an in-app updater. App updates are delivered by the Mac App Store.
+The sandboxed Mac App Store build does not execute external coding-agent command-line tools inside the sandbox and does not contain an in-app updater. Optional CLI requests use the authenticated loopback companion described above. App updates are delivered by the Mac App Store.
 
 ## Files and permissions
 

--- a/app-store/review-notes.md
+++ b/app-store/review-notes.md
@@ -17,7 +17,7 @@ MarkuprPlus is a menu bar app for creating structured visual-feedback reports fo
 
 Version 3.1.0 restores optional compatibility with Codex CLI, Claude Code CLI, OpenCode, Cursor Agent, Qwen Code, Goose, Amp, Kiro, and Aider. This feature is not required to complete the review walkthrough above.
 
-To test it, install the public npm package in Terminal with `npm install -g markuprx@latest`, run `markuprx bridge install`, then run `markuprx bridge token`. In MarkuprPlus, open Settings → Advanced, paste that token into CLI Integrations, and choose any compatible CLI already installed and signed in for the reviewer. `markuprx bridge status` reports whether the per-user companion is running.
+To test it, install the versioned package from the public project release in Terminal with `npm install -g https://github.com/hashfunction/MarkuprPlus/releases/download/v3.1.0/markuprx-3.1.0.tgz`, run `markuprx bridge install`, then run `markuprx bridge token`. In MarkuprPlus, open Settings → Advanced, paste that token into CLI Integrations, and choose any compatible CLI already installed and signed in for the reviewer. `markuprx bridge status` reports whether the per-user companion is running.
 
 The companion binds only to IPv4 loopback at `127.0.0.1:49647`, requires bearer-token authentication, and accepts only a fixed structured report protocol. The Mac App Store app does not execute external command-line tools inside its sandbox, does not accept or send arbitrary shell commands, and does not install the companion. The separately installed companion invokes only the provider explicitly selected by the user.
 

--- a/docs/superpowers/plans/2026-08-30-markuprplus-cli-bridge.md
+++ b/docs/superpowers/plans/2026-08-30-markuprplus-cli-bridge.md
@@ -1,0 +1,613 @@
+# MarkuprPlus CLI Bridge Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Restore all nine CLI report providers in the sandboxed Mac App Store edition through an authenticated, separately installed local companion, then build and submit MarkuprPlus 3.1.0 as an App Store update.
+
+**Architecture:** The npm-installed `markuprx` executable hosts a launchd-managed HTTP service on IPv4 loopback and reuses the existing direct-build CLI analyzers. The Store app uses bridge-backed implementations of the existing provider adapter interface, stores the bridge token in Keychain through dedicated IPC, and never launches or configures an external process itself.
+
+**Tech Stack:** TypeScript, Node.js HTTP and crypto APIs, Electron, React, Zod, Commander, launchd, Vitest, Playwright, electron-vite, electron-builder MAS, App Store Connect.
+
+**Spec:** `docs/superpowers/specs/2026-08-30-markuprplus-cli-bridge-design.md`
+
+## Global Constraints
+
+- Protocol version is `1`; the production endpoint is `http://127.0.0.1:49647`.
+- Authentication uses a 32-byte base64url bearer token; it never appears in URLs or logs.
+- Only `codex-cli`, `claude-cli`, `opencode-cli`, `cursor-cli`, `qwen-cli`, `goose-cli`, `amp-cli`, `kiro-cli`, and `aider-cli` may cross the bridge.
+- Requests never carry an executable, arguments, environment, working directory, configuration path, URL, shell text, or arbitrary filesystem path.
+- Maximum request body is 32 MiB; at most 20 screenshots of at most 8 MiB decoded each; at most 2,000 transcript events and 2,000 feedback items.
+- Provider connection calls time out after two seconds; analysis transport times out after 190 seconds.
+- The bridge runs one analysis at a time and returns `429 BRIDGE_BUSY` for another.
+- The Store application remains useful without the bridge and retains Local Rules fallback.
+- Direct-build CLI execution behavior remains unchanged.
+- Release version is `3.1.0`; Mac App Store build version is `3`.
+- App Store submission happens only after source, unit, UI, build, signing, and MAS package verification pass.
+
+---
+
+### Task 1: Versioned, Path-Free Bridge Protocol
+
+**Files:**
+- Create: `src/shared/cliBridgeProtocol.ts`
+- Create: `src/bridge/BridgeSession.ts`
+- Test: `tests/unit/cliBridgeProtocol.test.ts`
+- Test: `tests/unit/bridgeSession.test.ts`
+
+**Interfaces:**
+- Produces: `CLI_BRIDGE_PROTOCOL_VERSION`, `CLI_BRIDGE_DEFAULT_HOST`, `CLI_BRIDGE_DEFAULT_PORT`, `CLI_BRIDGE_PROVIDER_IDS`, `CliBridgeProvider`, `BridgeSessionPayload`, `BridgeAnalyzeRequest`, `BridgeErrorEnvelope`, `parseBridgeAnalyzeRequest(value)`, `serializeBridgeSession(session)`, and `deserializeBridgeSession(payload)`.
+- Consumes: existing `Session`, `AnalysisProviderStatus`, `AnalysisModelOption`, and `AIAnalysisResult` types.
+
+- [ ] **Step 1: Write failing protocol contract tests**
+
+Assert the exact provider allowlist and constants, successful parsing of a minimal analysis request, and rejection of unknown provider IDs, unknown properties, control characters in model IDs, more than 20 screenshots, invalid base64, decoded screenshots larger than 8 MiB, and arrays longer than 2,000.
+
+```ts
+expect(CLI_BRIDGE_PROVIDER_IDS).toEqual([
+  'codex-cli', 'claude-cli', 'opencode-cli', 'cursor-cli', 'qwen-cli',
+  'goose-cli', 'amp-cli', 'kiro-cli', 'aider-cli',
+]);
+expect(() => parseBridgeAnalyzeRequest({
+  provider: 'ollama', session: minimalBridgeSession,
+})).toThrow(/unsupported provider/i);
+```
+
+- [ ] **Step 2: Run the protocol test and verify RED**
+
+Run: `npx vitest run tests/unit/cliBridgeProtocol.test.ts`
+
+Expected: FAIL because `src/shared/cliBridgeProtocol.ts` does not exist.
+
+- [ ] **Step 3: Implement strict protocol types and schemas**
+
+Use strict Zod objects. Define `BridgeSessionPayload` with JSON-safe session, feedback, transcript, metadata, and screenshot fields. Calculate decoded base64 size before calling `Buffer.from`. Export stable error codes:
+
+```ts
+export type CliBridgeErrorCode =
+  | 'AUTH_REQUIRED' | 'AUTH_INVALID' | 'METHOD_NOT_ALLOWED' | 'NOT_FOUND'
+  | 'PAYLOAD_TOO_LARGE' | 'INVALID_REQUEST' | 'PROVIDER_UNSUPPORTED'
+  | 'BRIDGE_BUSY' | 'PROVIDER_UNAVAILABLE' | 'ANALYSIS_TIMEOUT'
+  | 'ANALYSIS_FAILED' | 'INTERNAL_ERROR' | 'BRIDGE_PROTOCOL_ERROR';
+```
+
+- [ ] **Step 4: Run the protocol test and verify GREEN**
+
+Run: `npx vitest run tests/unit/cliBridgeProtocol.test.ts`
+
+Expected: PASS with zero failures.
+
+- [ ] **Step 5: Write failing session round-trip tests**
+
+Construct a real `Session` with transcript events, feedback, capture metadata, and PNG/JPEG screenshots. Assert serialization contains no path-like metadata keys (`recordingPath`, `audioPath`, `screenshotPath`) and deserialization restores `Buffer` objects and analyzer-relevant timestamps.
+
+- [ ] **Step 6: Run the session test and verify RED**
+
+Run: `npx vitest run tests/unit/bridgeSession.test.ts`
+
+Expected: FAIL because the conversion functions do not exist.
+
+- [ ] **Step 7: Implement path-free session conversion**
+
+Copy JSON-compatible metadata but explicitly omit all path fields. Preserve source name, source type, capture context, marked-issue content without `screenshotPath`, transcript events, and feedback items. Decode only validated PNG and JPEG screenshots.
+
+- [ ] **Step 8: Run both tests and verify GREEN**
+
+Run: `npx vitest run tests/unit/cliBridgeProtocol.test.ts tests/unit/bridgeSession.test.ts`
+
+Expected: PASS with zero failures.
+
+- [ ] **Step 9: Commit the protocol**
+
+```bash
+git add src/shared/cliBridgeProtocol.ts src/bridge/BridgeSession.ts tests/unit/cliBridgeProtocol.test.ts tests/unit/bridgeSession.test.ts
+git commit -m "feat: define secure CLI bridge protocol"
+```
+
+---
+
+### Task 2: Authenticated Loopback Companion Server
+
+**Files:**
+- Create: `src/bridge/BridgeAuth.ts`
+- Create: `src/bridge/BridgeErrors.ts`
+- Create: `src/bridge/CliBridgeServer.ts`
+- Test: `tests/unit/cliBridgeServer.test.ts`
+- Test: `tests/integration/cliBridgeHttp.test.ts`
+
+**Interfaces:**
+- Consumes: Task 1 protocol parsing and conversion; `AnalysisProviderRegistry` from the existing CLI provider registry.
+- Produces: `generateBridgeToken()`, `isAuthorized(header, token)`, `createCliBridgeServer(options)`, `startCliBridgeServer(options)`, and `CliBridgeServerHandle.close()`.
+
+- [ ] **Step 1: Write failing authentication and routing tests**
+
+Use an injected fake provider registry and an ephemeral port. Assert health is the only unauthenticated endpoint; provider routes require a bearer token; token comparisons accept only an exact 32-byte token; invalid Host values fail; responses set `Cache-Control: no-store` and omit CORS headers; wrong methods and paths return stable JSON errors without stack traces.
+
+```ts
+const response = await fetch(`${origin}/v1/providers`);
+expect(response.status).toBe(401);
+expect(await response.json()).toEqual({
+  error: { code: 'AUTH_REQUIRED', message: 'Bridge authentication is required.' },
+});
+```
+
+- [ ] **Step 2: Run the server unit test and verify RED**
+
+Run: `npx vitest run tests/unit/cliBridgeServer.test.ts`
+
+Expected: FAIL because the server modules do not exist.
+
+- [ ] **Step 3: Implement token authentication, sanitized errors, and exact routing**
+
+Bind production only to `127.0.0.1`. Validate `Host` as `127.0.0.1:<port>` or `localhost:<port>`, compare decoded tokens using `timingSafeEqual`, limit the incoming body while streaming, set `Content-Type: application/json` and `Cache-Control: no-store`, and serialize no stack traces.
+
+- [ ] **Step 4: Implement provider and analysis handlers**
+
+Map `/providers`, provider test, and models to registry discovery. Parse analysis through Task 1, reconstruct the session, and call only `registry.get(request.provider)`. Use an in-memory busy flag cleared in `finally`; return `BRIDGE_BUSY` before parsing a second analysis body.
+
+- [ ] **Step 5: Run the server unit test and verify GREEN**
+
+Run: `npx vitest run tests/unit/cliBridgeServer.test.ts`
+
+Expected: PASS with zero failures.
+
+- [ ] **Step 6: Write and run real HTTP integration tests**
+
+Exercise an actual ephemeral loopback listener. Assert provider discovery, model response, analysis result, forced discovery, a 32 MiB streaming cutoff, concurrent `429`, and sanitized `502` behavior.
+
+Run: `npx vitest run tests/integration/cliBridgeHttp.test.ts`
+
+Expected before final implementation: FAIL on missing timeout/concurrency behavior. Expected after completing the server: PASS with zero failures.
+
+- [ ] **Step 7: Commit the companion server**
+
+```bash
+git add src/bridge/BridgeAuth.ts src/bridge/BridgeErrors.ts src/bridge/CliBridgeServer.ts tests/unit/cliBridgeServer.test.ts tests/integration/cliBridgeHttp.test.ts
+git commit -m "feat: add authenticated CLI bridge server"
+```
+
+---
+
+### Task 3: Per-User LaunchAgent and CLI Lifecycle
+
+**Files:**
+- Create: `src/bridge/BridgeConfig.ts`
+- Create: `src/bridge/BridgeLaunchAgent.ts`
+- Create: `src/bridge/BridgeCommand.ts`
+- Modify: `src/cli/index.ts`
+- Modify: `scripts/build-cli.mjs`
+- Modify: `package.json`
+- Modify: `package-lock.json`
+- Test: `tests/unit/bridgeConfig.test.ts`
+- Test: `tests/unit/bridgeLaunchAgent.test.ts`
+- Test: `tests/unit/bridgeCommand.test.ts`
+- Test: `tests/unit/cliBuild.test.ts`
+
+**Interfaces:**
+- Consumes: Task 2 `startCliBridgeServer`; existing `createCliAnalysisProviderRegistry()`.
+- Produces: `resolveBridgePaths(home)`, `loadOrCreateBridgeConfig(paths)`, `renderBridgeLaunchAgent(input)`, `planBridgeInstall(input)`, `planBridgeUninstall(input)`, and Commander subcommands under `markuprx bridge`.
+
+- [ ] **Step 1: Write failing configuration and permissions tests**
+
+Use temporary directories. Assert a new configuration receives a 43-character base64url token, state directory mode `0700`, file mode `0600`, an existing valid token is retained, malformed configuration is rejected rather than replaced, and token rotation atomically replaces only the secret.
+
+- [ ] **Step 2: Run configuration tests and verify RED**
+
+Run: `npx vitest run tests/unit/bridgeConfig.test.ts`
+
+Expected: FAIL because `BridgeConfig.ts` does not exist.
+
+- [ ] **Step 3: Implement bridge paths and secure atomic configuration writes**
+
+Use `mkdir`, a same-directory temporary file with `open(..., 0o600)`, `rename`, and explicit `chmod`. Never use shell interpolation or broad recursive deletion.
+
+- [ ] **Step 4: Run configuration tests and verify GREEN**
+
+Run: `npx vitest run tests/unit/bridgeConfig.test.ts`
+
+Expected: PASS.
+
+- [ ] **Step 5: Write failing launch-agent planning tests**
+
+Assert XML escaping, exact program arguments, `RunAtLoad`, `KeepAlive`, log paths inside bridge state, GUI domain `gui/<uid>`, idempotent replacement, rejection of `npx` cache paths, unsupported platforms, and uninstall targets limited to the exact plist/config files.
+
+- [ ] **Step 6: Run launch-agent tests and verify RED**
+
+Run: `npx vitest run tests/unit/bridgeLaunchAgent.test.ts`
+
+Expected: FAIL because launch-agent planning does not exist.
+
+- [ ] **Step 7: Implement launch-agent rendering and command execution**
+
+Invoke `/bin/launchctl` with argument arrays through `spawn`, never a shell. Use `bootstrap`, `bootout`, and `kickstart -k`; treat already-loaded and already-unloaded exit results idempotently. `uninstall` resolves and validates exact owned paths before unlinking them.
+
+- [ ] **Step 8: Add failing CLI command tests, then implement commands**
+
+Test `install`, `serve`, `start`, `stop`, `status`, `token`, `rotate-token`, and `uninstall` with injected lifecycle functions. Then register the command tree in `src/cli/index.ts`. `status` must never print the token; `token` must print it only when explicitly invoked.
+
+Run: `npx vitest run tests/unit/bridgeCommand.test.ts`
+
+Expected after implementation: PASS.
+
+- [ ] **Step 9: Prove the npm CLI bundle contains the bridge**
+
+Add a build test that runs `node scripts/build-cli.mjs`, invokes `node dist/cli/index.mjs bridge --help`, and asserts all lifecycle commands are present.
+
+Run: `npx vitest run tests/unit/cliBuild.test.ts`
+
+Expected after implementation: PASS.
+
+- [ ] **Step 10: Commit bridge lifecycle support**
+
+```bash
+git add src/bridge/BridgeConfig.ts src/bridge/BridgeLaunchAgent.ts src/bridge/BridgeCommand.ts src/cli/index.ts scripts/build-cli.mjs package.json package-lock.json tests/unit/bridgeConfig.test.ts tests/unit/bridgeLaunchAgent.test.ts tests/unit/bridgeCommand.test.ts tests/unit/cliBuild.test.ts
+git commit -m "feat: install CLI bridge as a user agent"
+```
+
+---
+
+### Task 4: Store Bridge Client and Provider Adapters
+
+**Files:**
+- Create: `src/main/ai/bridge/CliBridgeClient.ts`
+- Create: `src/main/ai/bridge/BridgeCliProvider.ts`
+- Modify: `src/main/ai/providers/AnalysisProviderRegistry.ts`
+- Modify: `src/main/ai/index.ts`
+- Test: `tests/unit/ai/cliBridgeClient.test.ts`
+- Test: `tests/unit/ai/bridgeCliProvider.test.ts`
+- Modify: `tests/unit/ai/analysisProviderRegistry.test.ts`
+
+**Interfaces:**
+- Consumes: Tasks 1-3 protocol and bridge server; `ISettingsManager.getApiKey('cli-bridge')`.
+- Produces: `CliBridgeClient`, `CliBridgeClient.getHealth()`, `.discoverProviders(force)`, `.testProvider(provider)`, `.models(provider)`, `.analyze(provider, session, modelId)`, `BridgeCliProvider`, and distribution-aware default registry options.
+
+- [ ] **Step 1: Write failing client transport tests**
+
+Inject `fetch`, token loading, base URL, and timers. Assert two-second discovery timeout, 190-second analysis timeout, authorization header behavior, no request when a token is absent, protocol-version rejection, error-envelope mapping, malformed JSON handling, and session serialization.
+
+- [ ] **Step 2: Run client tests and verify RED**
+
+Run: `npx vitest run tests/unit/ai/cliBridgeClient.test.ts`
+
+Expected: FAIL because the client does not exist.
+
+- [ ] **Step 3: Implement the minimal typed bridge client**
+
+Use `AbortSignal.timeout` or a locally managed `AbortController`. Never log request bodies or headers. Map connection refusal to `Start MarkuprPlus CLI Bridge`, missing token to `Pair MarkuprPlus Bridge`, and malformed responses to `BRIDGE_PROTOCOL_ERROR`.
+
+- [ ] **Step 4: Run client tests and verify GREEN**
+
+Run: `npx vitest run tests/unit/ai/cliBridgeClient.test.ts`
+
+Expected: PASS.
+
+- [ ] **Step 5: Write failing adapter and registry distribution tests**
+
+Assert one bridge adapter per CLI ID, correct status/model/analysis forwarding, direct distribution using existing local adapters, MAS distribution using bridge adapters, and Ollama/LM Studio/Anthropic remaining in both.
+
+```ts
+const mas = createDefaultAnalysisProviderRegistry(settings, {
+  distribution: 'mas', bridgeClient,
+});
+expect(mas.get('codex-cli')).toBeInstanceOf(BridgeCliProvider);
+expect(mas.get('ollama')).toMatchObject({ id: 'ollama' });
+```
+
+- [ ] **Step 6: Run adapter/registry tests and verify RED**
+
+Run: `npx vitest run tests/unit/ai/bridgeCliProvider.test.ts tests/unit/ai/analysisProviderRegistry.test.ts`
+
+Expected: FAIL because MAS adapters are absent.
+
+- [ ] **Step 7: Implement bridge adapters and distribution routing**
+
+Replace the boolean `allowCliProviders` parameter with:
+
+```ts
+export interface DefaultAnalysisProviderRegistryOptions {
+  distribution?: DistributionKind;
+  bridgeClient?: CliBridgeClient;
+}
+```
+
+Default `distribution` through `currentDistribution()`. Direct registers existing analyzers; MAS registers `BridgeCliProvider` instances using one shared client.
+
+- [ ] **Step 8: Run provider and pipeline regressions**
+
+Run: `npx vitest run tests/unit/ai/bridgeCliProvider.test.ts tests/unit/ai/analysisProviderRegistry.test.ts tests/unit/ai/aiPipelineManager.test.ts tests/unit/analysisProviderIpc.test.ts`
+
+Expected: PASS.
+
+- [ ] **Step 9: Commit Store provider routing**
+
+```bash
+git add src/main/ai/bridge/CliBridgeClient.ts src/main/ai/bridge/BridgeCliProvider.ts src/main/ai/providers/AnalysisProviderRegistry.ts src/main/ai/index.ts tests/unit/ai/cliBridgeClient.test.ts tests/unit/ai/bridgeCliProvider.test.ts tests/unit/ai/analysisProviderRegistry.test.ts
+git commit -m "feat: route Store CLI providers through bridge"
+```
+
+---
+
+### Task 5: Secure Pairing IPC and Preload API
+
+**Files:**
+- Modify: `src/shared/types.ts`
+- Create: `src/main/ipc/cliBridgeHandlers.ts`
+- Modify: `src/main/ipc/index.ts`
+- Modify: `src/main/ipc/settingsHandlers.ts`
+- Modify: `src/preload/index.ts`
+- Modify: `src/renderer/types/electron.d.ts`
+- Test: `tests/unit/cliBridgeIpc.test.ts`
+- Test: `tests/unit/cliBridgePreload.test.ts`
+- Modify: `tests/unit/navigationPreload.test.ts`
+
+**Interfaces:**
+- Consumes: Task 4 client and `ISettingsManager` secure secret storage.
+- Produces: `CliBridgeConnectionStatus`, IPC channels `CLI_BRIDGE_STATUS`, `CLI_BRIDGE_PAIR`, and `CLI_BRIDGE_FORGET`; renderer API `window.markuprx.cliBridge.status()`, `.pair(token)`, and `.forget()`.
+
+- [ ] **Step 1: Write failing IPC security tests**
+
+Assert status never returns a token, Pair rejects malformed token lengths without network access, Pair validates via authenticated discovery before saving, failed validation preserves an existing valid token, Forget deletes the secret, changes a selected CLI provider to `rules`, and direct distribution returns `not-applicable`.
+
+- [ ] **Step 2: Run IPC tests and verify RED**
+
+Run: `npx vitest run tests/unit/cliBridgeIpc.test.ts`
+
+Expected: FAIL because bridge IPC is undefined.
+
+- [ ] **Step 3: Implement dedicated bridge IPC**
+
+Do not add `cli-bridge` to the generic renderer-readable API-key service allowlist. Main-process handlers alone call `getApiKey`, `setApiKey`, and `deleteApiKey` for the service. Add deletion to Clear All Data.
+
+- [ ] **Step 4: Run IPC tests and verify GREEN**
+
+Run: `npx vitest run tests/unit/cliBridgeIpc.test.ts`
+
+Expected: PASS.
+
+- [ ] **Step 5: Write failing preload surface tests**
+
+Assert the three exact IPC calls and prove the renderer-facing TypeScript interface has no token getter.
+
+- [ ] **Step 6: Implement and verify the preload API**
+
+Run: `npx vitest run tests/unit/cliBridgePreload.test.ts tests/unit/navigationPreload.test.ts && npm run typecheck`
+
+Expected after implementation: PASS and zero type errors.
+
+- [ ] **Step 7: Commit pairing IPC**
+
+```bash
+git add src/shared/types.ts src/main/ipc/cliBridgeHandlers.ts src/main/ipc/index.ts src/main/ipc/settingsHandlers.ts src/preload/index.ts src/renderer/types/electron.d.ts tests/unit/cliBridgeIpc.test.ts tests/unit/cliBridgePreload.test.ts tests/unit/navigationPreload.test.ts
+git commit -m "feat: add secure CLI bridge pairing"
+```
+
+---
+
+### Task 6: Store Bridge Setup and Provider UX
+
+**Files:**
+- Create: `src/renderer/components/settings/CliBridgeSetup.tsx`
+- Create: `src/renderer/components/settings/cliBridgeViewState.ts`
+- Modify: `src/renderer/components/settings/AdvancedTab.tsx`
+- Modify: `src/renderer/components/settings/AnalysisProviderSelector.tsx`
+- Modify: `src/renderer/components/settings/analysisProviderOptions.ts`
+- Modify: `src/renderer/components/settings/useSettingsPanel.ts`
+- Modify: `src/renderer/components/SettingsPanel.tsx`
+- Test: `tests/unit/cliBridgeViewState.test.ts`
+- Modify: `tests/unit/analysisProviderOptions.test.ts`
+- Modify: `tests/unit/analysisProviderViewState.test.ts`
+- Modify: `tests/ui/markuprx-electron.spec.ts`
+
+**Interfaces:**
+- Consumes: Task 5 `window.markuprx.cliBridge` API and `CliBridgeConnectionStatus`.
+- Produces: Store-only setup panel, pairing handlers in `useSettingsPanel`, all provider cards in MAS, and `Via MarkuprPlus Bridge` CLI status copy.
+
+- [ ] **Step 1: Write failing pure view-state and provider-option tests**
+
+Assert Not paired, Bridge offline, Version incompatible, and Connected copy/actions. Change the MAS provider expectation from four cards to all thirteen; ensure MAS CLI descriptions mention the bridge while direct descriptions remain unchanged.
+
+- [ ] **Step 2: Run the pure renderer tests and verify RED**
+
+Run: `npx vitest run tests/unit/cliBridgeViewState.test.ts tests/unit/analysisProviderOptions.test.ts tests/unit/analysisProviderViewState.test.ts`
+
+Expected: FAIL on the old MAS filter and missing view state.
+
+- [ ] **Step 3: Implement view-state helpers and provider option transformation**
+
+`providerOptionsForDistribution('mas')` returns every option and copies CLI options with bridge-specific descriptions. Do not mutate the direct option constants.
+
+- [ ] **Step 4: Implement Store-only pairing state in the settings hook**
+
+Track token input locally; load status without retrieving the saved token; pair through dedicated IPC; clear the input after success; refresh providers after Pair/Forget/Test; preserve errors until the next action.
+
+- [ ] **Step 5: Implement the accessible setup panel**
+
+Use a password input, visible labels, status text, Pair/Test/Forget/Refresh buttons, and copyable commands:
+
+```text
+npm install -g markuprx
+markuprx bridge install
+```
+
+The Store app displays but never executes these commands. Render the panel only when `currentDistribution() === 'mas'`.
+
+- [ ] **Step 6: Run renderer tests and typecheck**
+
+Run: `npx vitest run tests/unit/cliBridgeViewState.test.ts tests/unit/analysisProviderOptions.test.ts tests/unit/analysisProviderViewState.test.ts tests/unit/appViewState.test.ts && npm run typecheck`
+
+Expected: PASS.
+
+- [ ] **Step 7: Add an Electron UI assertion and run it**
+
+Build the MAS renderer and assert Advanced Settings shows the bridge panel and Codex/OpenCode cards while the direct build omits the setup panel.
+
+Run: `npm run build:desktop && npx playwright test tests/ui/markuprx-electron.spec.ts`
+
+Expected: PASS.
+
+- [ ] **Step 8: Commit the Store UX**
+
+```bash
+git add src/renderer/components/settings/CliBridgeSetup.tsx src/renderer/components/settings/cliBridgeViewState.ts src/renderer/components/settings/AdvancedTab.tsx src/renderer/components/settings/AnalysisProviderSelector.tsx src/renderer/components/settings/analysisProviderOptions.ts src/renderer/components/settings/useSettingsPanel.ts src/renderer/components/SettingsPanel.tsx tests/unit/cliBridgeViewState.test.ts tests/unit/analysisProviderOptions.test.ts tests/unit/analysisProviderViewState.test.ts tests/ui/markuprx-electron.spec.ts
+git commit -m "feat: add Store CLI bridge setup"
+```
+
+---
+
+### Task 7: Release Documentation, Privacy, and Version 3.1.0
+
+**Files:**
+- Modify: `package.json`
+- Modify: `package-lock.json`
+- Modify: `electron-builder.mas.yml`
+- Modify: `CHANGELOG.md`
+- Modify: `README.md`
+- Modify: `site/privacy.html`
+- Modify: `app-store/metadata/en-US.md`
+- Modify: `app-store/review-notes.md`
+- Modify: `app-store/privacy-answers.md`
+- Modify: `tests/unit/appStoreMetadata.test.ts`
+- Test: `tests/unit/cliBridgeDocumentation.test.ts`
+
+**Interfaces:**
+- Consumes: final bridge commands and Store UX wording.
+- Produces: version `3.1.0`, build `3`, accurate public instructions, privacy disclosure, review walkthrough, and App Store What's New copy.
+
+- [ ] **Step 1: Write failing release-copy tests**
+
+Assert package versions, build version, install/pair/status/rotate/uninstall commands, optional-companion language, loopback disclosure, Local Rules review path, no claim that the Store app directly executes external tools, and App Store field limits.
+
+- [ ] **Step 2: Run metadata tests and verify RED**
+
+Run: `npx vitest run tests/unit/appStoreMetadata.test.ts tests/unit/cliBridgeDocumentation.test.ts`
+
+Expected: FAIL on version and missing bridge disclosures.
+
+- [ ] **Step 3: Update release and user documentation**
+
+Set package and lockfile version to `3.1.0`, MAS `buildVersion` to `3`, add a 3.1.0 changelog entry, and document the complete lifecycle. App Store description names CLI compatibility only through the optional local companion. Review notes lead with a companion-free Local Rules walkthrough and separately disclose optional bridge testing.
+
+- [ ] **Step 4: Run metadata tests and verify GREEN**
+
+Run: `npx vitest run tests/unit/appStoreMetadata.test.ts tests/unit/cliBridgeDocumentation.test.ts`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit release documentation**
+
+```bash
+git add package.json package-lock.json electron-builder.mas.yml CHANGELOG.md README.md site/privacy.html app-store/metadata/en-US.md app-store/review-notes.md app-store/privacy-answers.md tests/unit/appStoreMetadata.test.ts tests/unit/cliBridgeDocumentation.test.ts
+git commit -m "docs: prepare MarkuprPlus 3.1.0 Store update"
+```
+
+---
+
+### Task 8: Full Verification and Real Local Bridge Smoke Test
+
+**Files:**
+- Modify only files required by failures that reproduce a feature regression, always after adding a failing regression test.
+
+**Interfaces:**
+- Consumes: Tasks 1-7.
+- Produces: verified source, npm bundles, direct desktop bundle, MAS desktop bundle, and a real local bridge/provider smoke result.
+
+- [ ] **Step 1: Run the bridge-focused suite**
+
+```bash
+npx vitest run \
+  tests/unit/cliBridgeProtocol.test.ts \
+  tests/unit/bridgeSession.test.ts \
+  tests/unit/cliBridgeServer.test.ts \
+  tests/integration/cliBridgeHttp.test.ts \
+  tests/unit/bridgeConfig.test.ts \
+  tests/unit/bridgeLaunchAgent.test.ts \
+  tests/unit/bridgeCommand.test.ts \
+  tests/unit/ai/cliBridgeClient.test.ts \
+  tests/unit/ai/bridgeCliProvider.test.ts \
+  tests/unit/cliBridgeIpc.test.ts \
+  tests/unit/cliBridgePreload.test.ts \
+  tests/unit/cliBridgeViewState.test.ts
+```
+
+Expected: PASS with zero failures.
+
+- [ ] **Step 2: Run static and full test gates**
+
+Run: `npm run lint && npm run typecheck && npm run test:ci`
+
+Expected: all commands exit zero with no new warnings.
+
+- [ ] **Step 3: Build every published runtime**
+
+Run: `npm run build && npm run build:mas`
+
+Expected: desktop, CLI, MCP, direct renderer, and MAS renderer builds exit zero. Inspect MAS renderer strings for Codex/OpenCode and direct main bundle behavior for local CLI adapters.
+
+- [ ] **Step 4: Run Electron UI and package-source checks**
+
+Run: `npx playwright test && npm run verify:brand && node scripts/verify-ci.mjs`
+
+Expected: PASS.
+
+- [ ] **Step 5: Smoke test a real foreground bridge without installing launchd state**
+
+Run `node dist/cli/index.mjs bridge serve` using a temporary configuration directory override reserved for tests, read the generated token with the explicit token command, call health and provider discovery, and execute one available provider against a controlled transcript-only session. Do not send user capture data.
+
+Expected: health reports protocol 1; at least one locally installed provider reports its real readiness; a ready provider returns a valid analysis result. If none is ready, record discovery evidence and keep the automated fake-provider analysis test as the execution proof.
+
+- [ ] **Step 6: Commit any test-proven verification fixes**
+
+Commit only focused corrections with their regression tests. End with `git status --short` showing only pre-existing user-owned untracked files outside this feature.
+
+---
+
+### Task 9: Signed MAS Package, Upload, and App Store Submission
+
+**Files:**
+- Generated: `release-mas/MarkuprPlus.app`
+- Generated: `release-mas/markuprplus-3.1.0-mas.pkg`
+- External: App Store Connect MarkuprPlus macOS version 3.1.0.
+
+**Interfaces:**
+- Consumes: verified Task 8 commit, Apple Distribution and Mac Installer Distribution identities, MAS provisioning profile, App Store Connect account.
+- Produces: signed universal MAS package, uploaded build 3, completed version metadata, selected processed build, and submitted App Store update.
+
+- [ ] **Step 1: Resolve release credentials without exposing secrets**
+
+Check available signing identities with `security find-identity -v -p codesigning`, resolve the exact provisioning profile path through configured environment or known release state, and verify the App Store Connect session. Print only presence/status, never private-key, API-key, password, or profile contents.
+
+- [ ] **Step 2: Build and verify the signed package**
+
+Run: `npm run package:mas`
+
+Expected: universal signed `.app` and installer `.pkg`; `npm run verify:mas` passes signature, profile, entitlements, architectures, and layout.
+
+- [ ] **Step 3: Perform independent binary checks**
+
+```bash
+codesign --verify --deep --strict --verbose=2 release-mas/MarkuprPlus.app
+codesign -d --entitlements :- release-mas/MarkuprPlus.app
+pkgutil --check-signature release-mas/markuprplus-3.1.0-mas.pkg
+lipo -archs release-mas/MarkuprPlus.app/Contents/MacOS/MarkuprPlus
+```
+
+Expected: valid nested signatures, App Sandbox/network/audio/user-selected-file entitlements, trusted installer signature, and `x86_64 arm64`.
+
+- [ ] **Step 4: Upload build 3**
+
+Use the available authenticated Apple upload path (Transporter/App Store Connect tooling) to upload the `.pkg`. Preserve upload logs without secrets and verify App Store Connect accepts the bundle/version/build tuple.
+
+- [ ] **Step 5: Wait for build processing and resolve validation errors**
+
+Monitor build 3 until processing completes. If Apple reports a validation error, capture its exact code/message, add a failing package regression test when locally reproducible, implement the smallest correction, rebuild, reverify, and upload a strictly higher build number.
+
+- [ ] **Step 6: Complete version 3.1.0 metadata**
+
+Create or select macOS version 3.1.0, apply the approved What's New, description, URLs, privacy declarations, age rating, export compliance, review notes, availability, and existing $9.99 price. Reuse valid screenshots unless App Store Connect requires replacements.
+
+- [ ] **Step 7: Select the processed build and submit for review**
+
+Select the processed build, resolve remaining App Store Connect validation items, and invoke Submit for Review. The user's instruction on 2026-08-30 to “build and submit to app store autonomously as an update” is the explicit action-time authorization for this submission.
+
+- [ ] **Step 8: Record release evidence**
+
+Report version, build, source commit, package path, signature verification, upload delivery identifier, App Store Connect processing state, selected build, and final submission state. Do not report or store secrets.

--- a/docs/superpowers/specs/2026-08-30-markuprplus-cli-bridge-design.md
+++ b/docs/superpowers/specs/2026-08-30-markuprplus-cli-bridge-design.md
@@ -1,0 +1,302 @@
+# MarkuprPlus CLI Bridge Design
+
+**Date:** 2026-08-30
+**Status:** Approved for implementation
+
+## Goal
+
+Restore Codex CLI, Claude Code CLI, OpenCode, Cursor Agent CLI, Qwen Code,
+Goose, Amp, Kiro CLI, and Aider as functional report-generation providers in
+the sandboxed Mac App Store edition without allowing the Store application to
+launch arbitrary external processes.
+
+The feature uses an optional, separately installed MarkuprPlus CLI Bridge. The
+Store application remains useful without the companion through Anthropic API,
+Ollama, LM Studio, and Local Rules.
+
+## Distribution Boundary
+
+The direct edition keeps its existing in-process CLI provider adapters. It does
+not require or automatically prefer the bridge.
+
+The Mac App Store edition exposes the same CLI provider identifiers but backs
+them with bridge adapters. It never performs CLI discovery or execution in the
+Store process. The Store application does not install, update, launch, or
+uninstall the companion.
+
+The bridge ships in the existing `markuprx` npm package and is installed by the
+user outside the Store application. Installation creates a per-user launchd
+agent. The application may show copyable installation and pairing instructions,
+but all installation commands are performed explicitly by the user.
+
+## Architecture
+
+The feature has four isolated units:
+
+1. **Portable bridge protocol** defines versioned request and response types,
+   validation limits, error codes, and conversion between a MarkuprPlus session
+   and a path-free JSON payload.
+2. **Companion server** authenticates loopback requests, discovers allowlisted
+   CLI providers, reconstructs an in-memory session, and delegates analysis to
+   the existing CLI adapters.
+3. **Store bridge client and adapters** implement the existing
+   `AnalysisProviderAdapter` interface over HTTP so the report pipeline remains
+   unchanged.
+4. **CLI lifecycle and Store settings UI** install and manage the per-user
+   launch agent outside the Store app, securely pair the two processes, and
+   explain connection state.
+
+The existing provider IDs and saved model selections remain unchanged. A report
+selected with a CLI provider continues through the existing analysis pipeline,
+including its Local Rules fallback and provenance fields.
+
+## Companion Lifecycle
+
+The `markuprx` executable gains these commands:
+
+- `markuprx bridge install` creates bridge state if needed, writes the launchd
+  property list, bootstraps the agent, and prints the pairing token once.
+- `markuprx bridge serve` runs the foreground HTTP server used by launchd.
+- `markuprx bridge start` and `markuprx bridge stop` control the installed agent.
+- `markuprx bridge status` reports installation, process, protocol, and provider
+  status without printing the secret.
+- `markuprx bridge token` prints the current pairing token on explicit request.
+- `markuprx bridge rotate-token` replaces the token and invalidates the previous
+  pairing.
+- `markuprx bridge uninstall` boots out the agent and removes only bridge-owned
+  launchd and configuration files after resolving their exact paths.
+
+The bridge listens at `127.0.0.1:49647`. Its state lives under
+`~/.config/markuprplus/bridge/`, and its LaunchAgent property list lives at
+`~/Library/LaunchAgents/com.trieflow.markuprplus.cli-bridge.plist`. The state
+directory is mode `0700`; the configuration containing the token is mode
+`0600`.
+
+The launchd property list uses the absolute Node executable and built
+`dist/cli/index.mjs` path from the installed package. Installation rejects
+temporary `npx` cache paths so the service cannot silently break when a cache is
+cleaned. Re-running install is idempotent and refreshes the property list for a
+new npm package location while retaining the existing token.
+
+The lifecycle implementation is macOS-only. `serve` remains directly runnable
+for automated tests, but installation commands return an actionable unsupported
+platform error elsewhere.
+
+## Protocol
+
+Protocol version `1` exposes:
+
+- `GET /v1/health`: unauthenticated liveness response containing bridge version,
+  protocol version, and whether pairing has been configured. It contains no
+  provider, path, process, or credential details.
+- `GET /v1/providers`: authenticated discovery for all allowlisted CLI providers.
+- `POST /v1/providers/:provider/test`: authenticated forced discovery for one
+  allowlisted CLI provider.
+- `GET /v1/providers/:provider/models`: authenticated model discovery for one
+  allowlisted CLI provider.
+- `POST /v1/analyze`: authenticated analysis with provider, optional model, and
+  a portable session payload.
+
+Every authenticated request uses `Authorization: Bearer <token>`. Tokens contain
+32 random bytes encoded as base64url. The Store app persists the token through
+the existing secure `SettingsManager` secret APIs using service name
+`cli-bridge`; the renderer never receives a stored token after saving it.
+
+The portable session contains:
+
+- session ID, state, start and optional end times;
+- source ID and the existing JSON-compatible session metadata;
+- feedback items and transcript events;
+- screenshot IDs, timestamps, dimensions, MIME type, and base64 bytes.
+
+It contains no filesystem paths. The bridge decodes screenshots into `Buffer`
+objects and invokes the existing analyzer with a temporary session. Existing
+analyzers may create their own private temporary files as they do in the direct
+edition.
+
+The protocol applies these exact limits before analysis:
+
+- request body: 32 MiB;
+- screenshots: at most 20;
+- decoded screenshot: at most 8 MiB each;
+- transcript events: at most 2,000;
+- feedback items: at most 2,000;
+- model ID: at most 200 characters with no control characters;
+- one active analysis request at a time;
+- analysis deadline: 190 seconds at the transport layer, preserving each
+  analyzer's existing 180-second process deadline.
+
+Unknown JSON properties, non-finite numbers, invalid base64, unsupported image
+types, non-CLI provider IDs, and invalid session states are rejected. Protocol
+errors use a JSON envelope with a stable code and sanitized message. CLI output,
+session contents, authorization headers, and tokens are never written to bridge
+logs.
+
+## Security Model
+
+The bridge assumes other unprivileged processes on the same Mac are untrusted.
+Its defenses are:
+
+- bind only to IPv4 loopback and reject non-loopback socket addresses;
+- require exact API paths and methods;
+- require the bearer token for every operation that reveals provider details or
+  performs work;
+- compare tokens with a timing-safe comparison;
+- reject missing or unexpected `Host` values rather than serving through DNS
+  rebinding hostnames;
+- allow only the nine compile-time CLI provider IDs;
+- never accept executable paths, command arguments, working directories,
+  environment variables, configuration paths, URLs, or shell text from the
+  client;
+- cap request size before buffering the entire body;
+- allow one analysis at a time and return `429 BRIDGE_BUSY` for another;
+- sanitize error messages using the same credential-redaction rules as existing
+  CLI diagnostics;
+- set `Cache-Control: no-store` and return no CORS headers.
+
+Loopback HTTP is acceptable for this local boundary because the bearer token is
+high entropy, never placed in a URL, and readable only from mode-restricted
+companion state or the Store app's secure secret storage. TLS would not add a
+useful identity guarantee without introducing a local certificate lifecycle.
+
+## Provider Routing
+
+`createDefaultAnalysisProviderRegistry` becomes distribution-aware:
+
+- `direct` registers the existing `CodexAnalyzer`, `ClaudeCliAnalyzer`, and
+  `ProfiledCliProvider` adapters;
+- `mas` registers one `BridgeCliProvider` per CLI provider ID plus Ollama,
+  LM Studio, and Anthropic API;
+- tests may inject a distribution and bridge client explicitly.
+
+`BridgeCliProvider.discover()` calls the bridge and returns an ordinary
+`AnalysisProviderStatus`. A missing token reports `Pair MarkuprPlus Bridge`.
+Connection refusal reports `Start MarkuprPlus CLI Bridge`. An incompatible
+protocol reports the installed and required versions without exposing any
+secret.
+
+`BridgeCliProvider.analyze()` serializes the session and returns the existing
+`AIAnalysisResult`. The central pipeline therefore retains current Local Rules
+fallback behavior without bridge-specific branching.
+
+## Store Settings Experience
+
+The Store edition displays all provider cards in the existing order. CLI cards
+use the `CLI` badge and add `Via MarkuprPlus Bridge` to their description or
+status. The direct edition's cards and descriptions remain unchanged.
+
+A Store-only bridge setup panel appears before the provider cards. It contains:
+
+- connection state: Not paired, Bridge offline, Version incompatible, or
+  Connected;
+- a password-style pairing-token field;
+- Pair, Test connection, Forget pairing, and Refresh actions as appropriate;
+- copyable terminal instructions for installing the published `markuprx`
+  package and running `markuprx bridge install`;
+- a clear statement that the optional companion is installed outside the Mac
+  App Store and runs only for the current user.
+
+Pair validates the token against authenticated provider discovery before saving
+it. Failed validation leaves the previous valid token intact. Forget pairing
+deletes the secret and changes a currently selected CLI provider to Local Rules
+so the next report does not fail unexpectedly.
+
+Provider discovery combines bridge-backed CLI statuses with the existing local
+and cloud providers. Settings discovery must remain responsive when the bridge
+is absent by using a two-second connection deadline. Analysis uses the longer
+190-second deadline.
+
+## App Store Compliance
+
+The Store binary remains sandboxed and self-contained for its core behavior. It
+does not download, install, update, launch, or modify the companion. The
+companion is an optional user-installed integration analogous to connecting to
+an already running local service. MarkuprPlus remains functional with Local
+Rules and the existing sandbox-safe providers when the companion is absent.
+
+Store metadata, privacy copy, and review notes must disclose:
+
+- the optional local companion;
+- loopback communication;
+- that report material is sent only to the locally running companion when a CLI
+  provider is explicitly selected;
+- that the companion invokes the user's separately installed and authenticated
+  CLI;
+- complete review steps using Local Rules without requiring companion setup.
+
+The Store review notes must not claim that the Store app directly executes
+external CLIs.
+
+## Error Handling
+
+Bridge transport errors map to concise, actionable provider diagnostics. The
+server returns these stable codes:
+
+- `AUTH_REQUIRED` and `AUTH_INVALID` (`401`);
+- `METHOD_NOT_ALLOWED` (`405`);
+- `NOT_FOUND` (`404`);
+- `PAYLOAD_TOO_LARGE` (`413`);
+- `INVALID_REQUEST` (`400`);
+- `PROVIDER_UNSUPPORTED` (`400`);
+- `BRIDGE_BUSY` (`429`);
+- `PROVIDER_UNAVAILABLE` (`503`);
+- `ANALYSIS_TIMEOUT` (`504`);
+- `ANALYSIS_FAILED` (`502`);
+- `INTERNAL_ERROR` (`500`).
+
+The server never returns stack traces. The client treats malformed responses as
+`BRIDGE_PROTOCOL_ERROR`. Report generation then uses the existing Local Rules
+fallback and records the sanitized reason in report provenance.
+
+## Testing
+
+Development follows red-green-refactor. Tests cover:
+
+- protocol validation, serialization round trips, and every payload limit;
+- token generation, file permissions, timing-safe authentication, Host checks,
+  route/method allowlisting, request size limiting, response headers, and log
+  redaction;
+- real loopback HTTP behavior using an ephemeral test port and injected fake
+  provider registry;
+- one-analysis concurrency and timeout behavior;
+- bridge adapters for discovery, model discovery, analysis, authentication,
+  incompatible versions, malformed responses, and connection refusal;
+- direct versus Store registry contents;
+- CLI lifecycle property-list generation, idempotent install planning, exact
+  path resolution, and safe uninstall planning without mutating the developer's
+  real launchd state;
+- secure pairing IPC and renderer state without exposing stored tokens;
+- Store and direct provider option ordering and copy;
+- existing provider, pipeline, settings, packaging, and Electron UI regressions;
+- CLI and MCP npm bundle construction, MAS desktop build, type checking, lint,
+  and the full unit suite.
+
+A manual local verification runs the companion in the foreground, pairs a MAS
+development build, confirms real provider discovery, and executes one available
+CLI against a controlled transcript. Signed Store packaging remains a separate
+release step because it needs distribution credentials and a provisioning
+profile.
+
+## Documentation and Release
+
+The README and website gain a CLI Bridge section with install, pairing, status,
+token rotation, troubleshooting, and uninstall instructions. The npm package
+includes all bridge runtime files through its existing bundled CLI entry point.
+
+The Store build version must be incremented before the next upload. Submission
+does not occur as part of implementation and still requires explicit action-time
+confirmation.
+
+## Success Criteria
+
+- All nine CLI providers appear in the Store settings UI.
+- With a valid paired bridge, Store discovery and report analysis work through
+  the user's installed CLI without spawning it from the Store process.
+- Without a bridge, Store startup and settings remain responsive and explain
+  the exact setup action.
+- Invalid clients cannot discover providers or trigger execution.
+- The bridge accepts no arbitrary executable, arguments, environment, working
+  directory, or filesystem path from the Store app.
+- The direct edition behaves exactly as before.
+- Store-safe providers and Local Rules continue working without the companion.
+- Automated verification passes for source, bundles, and MAS behavior.

--- a/electron-builder.mas.yml
+++ b/electron-builder.mas.yml
@@ -2,7 +2,7 @@ appId: com.eddiesanjuan.markuprx
 productName: MarkuprPlus
 executableName: MarkuprPlus
 copyright: Copyright 2026 Trieflow LLC
-buildVersion: "2"
+buildVersion: "3"
 
 directories:
   output: release-mas

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "markuprx",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "markuprx",
-      "version": "3.0.0",
+      "version": "3.1.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "markuprx",
   "productName": "MarkuprPlus",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "Record your screen, narrate feedback, get structured Markdown with screenshots. Desktop app, CLI, and MCP server for AI coding agents like Claude Code, Cursor, and Windsurf.",
   "type": "module",
   "main": "dist/main/index.mjs",

--- a/scripts/smoke-packaged-app.mjs
+++ b/scripts/smoke-packaged-app.mjs
@@ -2,13 +2,16 @@
 
 import { _electron as electron } from '@playwright/test';
 import { constants } from 'node:fs';
-import { access, mkdir, mkdtemp, rm } from 'node:fs/promises';
+import { access, mkdir, mkdtemp, readFile, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
 
 import { runStartupProbe } from './lib/startup-probe.mjs';
 
 const PUBLIC_PRODUCT_NAME = 'MarkuprPlus';
+const { version: expectedVersion } = JSON.parse(
+  await readFile(new URL('../package.json', import.meta.url), 'utf8'),
+);
 
 function defaultPackagedLayout(platform, arch, releaseRoot = resolve('release')) {
   if (platform === 'darwin') {
@@ -158,7 +161,10 @@ try {
       runtime.name === PUBLIC_PRODUCT_NAME,
       `Unexpected application name: ${runtime.name}.`,
     );
-    assertRuntime(runtime.version === '3.0.0', `Unexpected application version: ${runtime.version}.`);
+    assertRuntime(
+      runtime.version === expectedVersion,
+      `Unexpected application version: ${runtime.version}; expected ${expectedVersion}.`,
+    );
     assertRuntime(
       title.includes(PUBLIC_PRODUCT_NAME),
       `Unexpected application title: ${title}.`,

--- a/scripts/verify-brand.mjs
+++ b/scripts/verify-brand.mjs
@@ -85,7 +85,7 @@ export function findBrandViolations(files, readFile, packageJson) {
   const expectedPackageFields = {
     name: 'markuprx',
     productName: 'MarkuprPlus',
-    version: '3.0.0',
+    version: '3.1.0',
     homepage: 'https://markuprplus.com',
     repository: {
       type: 'git',

--- a/site/privacy.html
+++ b/site/privacy.html
@@ -6,7 +6,7 @@
   <title>Privacy Policy — MarkuprPlus</title>
   <meta name="description" content="How MarkuprPlus handles recordings, reports, API keys, and optional AI providers.">
   <link rel="canonical" href="https://markuprplus.com/privacy">
-  <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32.png?v=3.0.0">
+  <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32.png?v=3.1.0">
   <style>
     :root {
       color-scheme: dark light;
@@ -40,7 +40,7 @@
   <header>
     <a class="wordmark" href="/">MarkuprPlus</a>
     <h1>Privacy Policy</h1>
-    <p class="updated">Effective August 20, 2026</p>
+    <p class="updated">Effective August 30, 2026</p>
   </header>
 
   <main>
@@ -56,11 +56,14 @@
     <h2>On-device processing</h2>
     <p>Local Rules creates structured reports without an AI service. Local Whisper transcription runs on your device after you install a model. Ollama and LM Studio connections use fixed loopback addresses on your Mac. MarkuprPlus does not send those local-provider requests to a developer-operated server.</p>
 
+    <h2>Optional local CLI companion</h2>
+    <p>The Mac App Store app can connect to a separately installed MarkuprPlus CLI Bridge on the fixed loopback address <code>127.0.0.1:49647</code>. The bridge requires a random pairing token stored in macOS Keychain. Transcript text and selected screenshots are sent only to this companion on your Mac when you explicitly select a compatible CLI report provider. The companion then invokes that selected CLI, which may contact its own provider under the account and privacy terms you configured for that tool. The App Store app does not execute shell commands, and neither the app nor the companion sends this material to a MarkuprPlus or Trieflow server.</p>
+
     <h2>Optional cloud providers</h2>
     <p>If you select a cloud provider, MarkuprPlus sends only the report material needed for that request to the provider you choose. For example, Anthropic API analysis may receive transcript text and selected screenshots, and optional cloud transcription may receive narration audio. Those providers process data under their own terms and privacy policies. MarkuprPlus does not silently switch to a different cloud provider.</p>
 
     <h2>API keys</h2>
-    <p>Keys you enter are stored in the macOS Keychain and are used only to contact the provider you selected. MarkuprPlus does not transmit your keys to a MarkuprPlus server.</p>
+    <p>Provider keys and the optional companion pairing token are stored in the macOS Keychain and are used only for their named connection. MarkuprPlus does not transmit these secrets to a MarkuprPlus server.</p>
 
     <h2>Permissions</h2>
     <p>macOS asks for Screen Recording permission so MarkuprPlus can capture the source you choose and Microphone permission so it can record narration. You can revoke either permission in System Settings. The Mac App Store edition runs in Apple's App Sandbox.</p>
@@ -72,7 +75,7 @@
     <p>Session files remain on your Mac until you remove them. You can delete captures from MarkuprPlus or Finder, clear app data from Settings, revoke permissions in System Settings, and remove provider keys from the app or Keychain Access. Cloud providers may retain submitted material according to the provider settings and policy associated with your account.</p>
 
     <h2>Distribution and updates</h2>
-    <p>MarkuprPlus is distributed through the Mac App Store, where Apple manages installation and updates. This policy covers the MarkuprPlus application; Apple and optional providers process data under their own policies.</p>
+    <p>MarkuprPlus is distributed through the Mac App Store, where Apple manages installation and updates. The optional local companion is installed separately through npm and has its own explicit lifecycle commands. This policy covers the MarkuprPlus application and companion; Apple and optional providers process data under their own policies.</p>
 
     <h2>Changes</h2>
     <p>If this policy changes materially, the effective date above will change and the updated policy will remain available at this URL.</p>

--- a/src/bridge/BridgeAuth.ts
+++ b/src/bridge/BridgeAuth.ts
@@ -1,0 +1,14 @@
+import { randomBytes, timingSafeEqual } from 'node:crypto';
+
+export function generateBridgeToken(): string {
+  return randomBytes(32).toString('base64url');
+}
+
+export function isAuthorized(header: string | undefined, configuredToken: string): boolean {
+  if (!header?.startsWith('Bearer ')) return false;
+  const candidate = header.slice('Bearer '.length);
+  const candidateBytes = Buffer.from(candidate, 'utf8');
+  const configuredBytes = Buffer.from(configuredToken, 'utf8');
+  if (candidateBytes.length !== configuredBytes.length) return false;
+  return timingSafeEqual(candidateBytes, configuredBytes);
+}

--- a/src/bridge/BridgeCommand.ts
+++ b/src/bridge/BridgeCommand.ts
@@ -1,0 +1,185 @@
+import { access } from 'node:fs/promises';
+import { homedir } from 'node:os';
+import { resolve } from 'node:path';
+import type { Command } from 'commander';
+import { startCliBridgeServer } from './CliBridgeServer';
+import { createBridgeProviderRegistry } from './BridgeProviderRegistry';
+import {
+  loadOrCreateBridgeConfig,
+  readBridgeConfig,
+  resolveBridgePaths,
+  rotateBridgeToken,
+} from './BridgeConfig';
+import {
+  bridgeLaunchAgentRunning,
+  installBridgeLaunchAgent,
+  startBridgeLaunchAgent,
+  stopBridgeLaunchAgent,
+  uninstallBridgeLaunchAgent,
+} from './BridgeLaunchAgent';
+
+export interface BridgeStatus {
+  installed: boolean;
+  running: boolean;
+  protocolVersion: number;
+}
+
+export interface BridgeLifecycle {
+  install(): Promise<{ token: string; created: boolean }>;
+  serve(): Promise<void>;
+  start(): Promise<void>;
+  stop(): Promise<void>;
+  status(): Promise<BridgeStatus>;
+  token(): Promise<string>;
+  rotateToken(): Promise<string>;
+  uninstall(): Promise<void>;
+}
+
+export interface BridgeCommandDependencies {
+  lifecycle: BridgeLifecycle;
+  write(line: string): void;
+  writeError(line: string): void;
+}
+
+function runtimeInput() {
+  const homeDirectory = homedir();
+  const stateOverride = process.env.MARKUPRPLUS_BRIDGE_STATE_DIR?.trim() || undefined;
+  const paths = resolveBridgePaths(homeDirectory, stateOverride);
+  const uid = process.getuid?.();
+  if (uid === undefined) throw new Error('Unable to resolve the current macOS user.');
+  return {
+    paths,
+    platform: process.platform,
+    uid,
+    nodePath: process.execPath,
+    cliPath: resolve(process.argv[1]),
+  };
+}
+
+export function createDefaultBridgeLifecycle(bridgeVersion: string): BridgeLifecycle {
+  return {
+    async install() {
+      const input = runtimeInput();
+      const { config, created } = await loadOrCreateBridgeConfig(input.paths);
+      await installBridgeLaunchAgent(input);
+      return { token: config.token, created };
+    },
+    async serve() {
+      const input = runtimeInput();
+      const { config } = await loadOrCreateBridgeConfig(input.paths);
+      const handle = await startCliBridgeServer({
+        token: config.token,
+        bridgeVersion,
+        registry: createBridgeProviderRegistry(),
+        port: config.port,
+      });
+      await new Promise<void>((resolvePromise) => {
+        const stop = () => {
+          void handle.close().finally(resolvePromise);
+        };
+        process.once('SIGINT', stop);
+        process.once('SIGTERM', stop);
+      });
+    },
+    async start() {
+      await startBridgeLaunchAgent(runtimeInput());
+    },
+    async stop() {
+      const { platform, uid, paths } = runtimeInput();
+      await stopBridgeLaunchAgent({ platform, uid, paths });
+    },
+    async status() {
+      const { platform, uid, paths } = runtimeInput();
+      let installed = true;
+      try {
+        await access(paths.launchAgentPath);
+        await readBridgeConfig(paths);
+      } catch {
+        installed = false;
+      }
+      return {
+        installed,
+        running: installed
+          ? await bridgeLaunchAgentRunning({ platform, uid, paths })
+          : false,
+        protocolVersion: 1,
+      };
+    },
+    async token() {
+      return (await readBridgeConfig(runtimeInput().paths)).token;
+    },
+    async rotateToken() {
+      const input = runtimeInput();
+      const config = await rotateBridgeToken(input.paths);
+      await installBridgeLaunchAgent(input);
+      return config.token;
+    },
+    async uninstall() {
+      const { platform, uid, paths } = runtimeInput();
+      await uninstallBridgeLaunchAgent({ platform, uid, paths });
+    },
+  };
+}
+
+function defaultDependencies(bridgeVersion: string): BridgeCommandDependencies {
+  return {
+    lifecycle: createDefaultBridgeLifecycle(bridgeVersion),
+    write: (line) => console.log(line),
+    writeError: (line) => console.error(line),
+  };
+}
+
+export function registerBridgeCommand(
+  program: Command,
+  dependencies: Partial<BridgeCommandDependencies> & { bridgeVersion?: string } = {},
+): void {
+  const defaults = defaultDependencies(dependencies.bridgeVersion || '0.0.0-dev');
+  const { lifecycle, write, writeError } = { ...defaults, ...dependencies };
+  const action = (operation: () => Promise<void>) => async () => {
+    try {
+      await operation();
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      writeError(message);
+      process.exitCode = 1;
+    }
+  };
+  const bridge = program.command('bridge').description('Manage the optional local CLI companion');
+
+  bridge.command('install').description('Install and start the per-user companion').action(action(async () => {
+    const result = await lifecycle.install();
+    write('MarkuprPlus CLI Bridge installed.');
+    if (result.created) {
+      write(`Pairing token: ${result.token}`);
+    } else {
+      write('Pairing token retained. Run `markuprx bridge token` to display it.');
+    }
+  }));
+  bridge.command('serve').description('Run the companion in the foreground').action(action(async () => {
+    await lifecycle.serve();
+  }));
+  bridge.command('start').description('Start the installed companion').action(action(async () => {
+    await lifecycle.start();
+    write('MarkuprPlus CLI Bridge started.');
+  }));
+  bridge.command('stop').description('Stop the installed companion').action(action(async () => {
+    await lifecycle.stop();
+    write('MarkuprPlus CLI Bridge stopped.');
+  }));
+  bridge.command('status').description('Show companion status without secrets').action(action(async () => {
+    const status = await lifecycle.status();
+    write(`Installed: ${status.installed ? 'yes' : 'no'}`);
+    write(`Running: ${status.running ? 'yes' : 'no'}`);
+    write(`Protocol: ${status.protocolVersion}`);
+  }));
+  bridge.command('token').description('Print the pairing token').action(action(async () => {
+    write(await lifecycle.token());
+  }));
+  bridge.command('rotate-token').description('Replace the pairing token and restart').action(action(async () => {
+    write(`New pairing token: ${await lifecycle.rotateToken()}`);
+  }));
+  bridge.command('uninstall').description('Remove the per-user companion').action(action(async () => {
+    await lifecycle.uninstall();
+    write('MarkuprPlus CLI Bridge uninstalled.');
+  }));
+}

--- a/src/bridge/BridgeConfig.ts
+++ b/src/bridge/BridgeConfig.ts
@@ -1,0 +1,148 @@
+import { randomUUID } from 'node:crypto';
+import {
+  chmod,
+  lstat,
+  mkdir,
+  open,
+  readFile,
+  rename,
+  unlink,
+} from 'node:fs/promises';
+import { join } from 'node:path';
+import { generateBridgeToken } from './BridgeAuth';
+import {
+  CLI_BRIDGE_DEFAULT_PORT,
+  CLI_BRIDGE_PROTOCOL_VERSION,
+} from '../shared/cliBridgeProtocol';
+
+export const CLI_BRIDGE_LAUNCH_AGENT_LABEL = 'com.trieflow.markuprplus.cli-bridge';
+
+export interface BridgePaths {
+  stateDirectory: string;
+  configPath: string;
+  stdoutLogPath: string;
+  stderrLogPath: string;
+  launchAgentPath: string;
+}
+
+export interface BridgeConfig {
+  token: string;
+  protocolVersion: number;
+  port: number;
+}
+
+export function resolveBridgePaths(
+  homeDirectory: string,
+  stateDirectoryOverride?: string,
+): BridgePaths {
+  const stateDirectory = stateDirectoryOverride
+    ? stateDirectoryOverride
+    : join(homeDirectory, '.config', 'markuprplus', 'bridge');
+  return {
+    stateDirectory,
+    configPath: join(stateDirectory, 'config.json'),
+    stdoutLogPath: join(stateDirectory, 'stdout.log'),
+    stderrLogPath: join(stateDirectory, 'stderr.log'),
+    launchAgentPath: join(
+      homeDirectory,
+      'Library',
+      'LaunchAgents',
+      `${CLI_BRIDGE_LAUNCH_AGENT_LABEL}.plist`,
+    ),
+  };
+}
+
+function validateBridgeConfig(value: unknown): BridgeConfig {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error('Invalid CLI bridge configuration.');
+  }
+  const object = value as Record<string, unknown>;
+  if (
+    Object.keys(object).sort().join(',') !== 'port,protocolVersion,token'
+    || typeof object.token !== 'string'
+    || !/^[A-Za-z0-9_-]{43}$/.test(object.token)
+    || Buffer.from(object.token, 'base64url').length !== 32
+    || object.protocolVersion !== CLI_BRIDGE_PROTOCOL_VERSION
+    || object.port !== CLI_BRIDGE_DEFAULT_PORT
+  ) {
+    throw new Error('Invalid CLI bridge configuration.');
+  }
+  return {
+    token: object.token,
+    protocolVersion: object.protocolVersion,
+    port: object.port,
+  };
+}
+
+async function ensureRegularFile(path: string): Promise<void> {
+  const details = await lstat(path);
+  if (!details.isFile() || details.isSymbolicLink()) {
+    throw new Error('Invalid CLI bridge configuration file.');
+  }
+}
+
+async function writeConfigAtomically(paths: BridgePaths, config: BridgeConfig): Promise<void> {
+  await mkdir(paths.stateDirectory, { recursive: true, mode: 0o700 });
+  await chmod(paths.stateDirectory, 0o700);
+  const temporaryPath = join(paths.stateDirectory, `.config-${randomUUID()}.tmp`);
+  const handle = await open(temporaryPath, 'wx', 0o600);
+  try {
+    await handle.writeFile(`${JSON.stringify(config, null, 2)}\n`, 'utf8');
+    await handle.sync();
+  } finally {
+    await handle.close();
+  }
+  try {
+    await rename(temporaryPath, paths.configPath);
+    await chmod(paths.configPath, 0o600);
+  } catch (error) {
+    await unlink(temporaryPath).catch(() => {});
+    throw error;
+  }
+}
+
+export async function readBridgeConfig(paths: BridgePaths): Promise<BridgeConfig> {
+  try {
+    await ensureRegularFile(paths.configPath);
+    const raw = await readFile(paths.configPath, 'utf8');
+    return validateBridgeConfig(JSON.parse(raw) as unknown);
+  } catch (error) {
+    if (error instanceof SyntaxError) {
+      throw new Error('Invalid CLI bridge configuration.');
+    }
+    throw error;
+  }
+}
+
+export async function loadOrCreateBridgeConfig(
+  paths: BridgePaths,
+  dependencies: { generateToken?: () => string } = {},
+): Promise<{ config: BridgeConfig; created: boolean }> {
+  try {
+    return { config: await readBridgeConfig(paths), created: false };
+  } catch (error) {
+    if (!(error instanceof Error && 'code' in error && error.code === 'ENOENT')) {
+      throw error;
+    }
+  }
+
+  const config: BridgeConfig = {
+    token: (dependencies.generateToken || generateBridgeToken)(),
+    protocolVersion: CLI_BRIDGE_PROTOCOL_VERSION,
+    port: CLI_BRIDGE_DEFAULT_PORT,
+  };
+  validateBridgeConfig(config);
+  await writeConfigAtomically(paths, config);
+  return { config, created: true };
+}
+
+export async function rotateBridgeToken(
+  paths: BridgePaths,
+  generateToken: () => string = generateBridgeToken,
+): Promise<BridgeConfig> {
+  const existing = await readBridgeConfig(paths);
+  const next = { ...existing, token: generateToken() };
+  validateBridgeConfig(next);
+  await writeConfigAtomically(paths, next);
+  return next;
+}

--- a/src/bridge/BridgeErrors.ts
+++ b/src/bridge/BridgeErrors.ts
@@ -1,0 +1,27 @@
+import type { CliBridgeErrorCode } from '../shared/cliBridgeProtocol';
+
+export class BridgeHttpError extends Error {
+  constructor(
+    public readonly status: number,
+    public readonly code: CliBridgeErrorCode,
+    message: string,
+  ) {
+    super(message);
+    this.name = 'BridgeHttpError';
+  }
+}
+
+export function sanitizeBridgeMessage(error: unknown, fallback: string): string {
+  const raw = error instanceof Error ? error.message : fallback;
+  const withoutControls = Array.from(raw, (character) => {
+    const code = character.charCodeAt(0);
+    return code <= 0x1f || (code >= 0x7f && code <= 0x9f) ? ' ' : character;
+  }).join('');
+  const sanitized = withoutControls
+    .replace(/\b(?:sk|gh[opusr]|github_pat)_[A-Za-z0-9_-]{8,}\b/gi, '[redacted]')
+    .replace(/\b(Bearer|api[_ -]?key|token)\s*[:=]\s*\S+/gi, '$1: [redacted]')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .slice(0, 500);
+  return sanitized || fallback;
+}

--- a/src/bridge/BridgeLaunchAgent.ts
+++ b/src/bridge/BridgeLaunchAgent.ts
@@ -1,0 +1,202 @@
+import { spawn } from 'node:child_process';
+import { lstat, mkdir, unlink, writeFile } from 'node:fs/promises';
+import { dirname, isAbsolute } from 'node:path';
+import {
+  CLI_BRIDGE_LAUNCH_AGENT_LABEL,
+  type BridgePaths,
+} from './BridgeConfig';
+
+export interface BridgeLaunchAgentInput {
+  platform: NodeJS.Platform;
+  uid: number;
+  nodePath: string;
+  cliPath: string;
+  paths: BridgePaths;
+}
+
+export interface BridgeInstallPlan {
+  plistPath: string;
+  plist: string;
+  bootoutArgs: string[];
+  bootstrapArgs: string[];
+  kickstartArgs: string[];
+}
+
+export interface BridgeUninstallPlan {
+  bootoutArgs: string[];
+  filesToRemove: string[];
+}
+
+export interface LaunchctlResult {
+  exitCode: number | null;
+  stdout: string;
+  stderr: string;
+}
+
+export type LaunchctlRunner = (args: string[]) => Promise<LaunchctlResult>;
+
+function escapeXml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;');
+}
+
+function requireInstallInput(input: BridgeLaunchAgentInput): void {
+  if (input.platform !== 'darwin') {
+    throw new Error('MarkuprPlus CLI Bridge installation is supported only on macOS.');
+  }
+  if (!isAbsolute(input.nodePath) || !isAbsolute(input.cliPath)) {
+    throw new Error('Bridge executable paths must be absolute.');
+  }
+  if (/(?:^|\/)\.npm\/_npx(?:\/|$)/.test(input.cliPath)) {
+    throw new Error('Install markuprx globally before installing the bridge; a temporary npx cache is not stable.');
+  }
+}
+
+export function renderBridgeLaunchAgent(
+  input: Omit<BridgeLaunchAgentInput, 'platform' | 'uid'>,
+): string {
+  const values = [input.nodePath, input.cliPath, 'bridge', 'serve'];
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>${CLI_BRIDGE_LAUNCH_AGENT_LABEL}</string>
+  <key>ProgramArguments</key>
+  <array>
+${values.map((value) => `    <string>${escapeXml(value)}</string>`).join('\n')}
+  </array>
+  <key>RunAtLoad</key>
+  <true/>
+  <key>KeepAlive</key>
+  <true/>
+  <key>ProcessType</key>
+  <string>Background</string>
+  <key>StandardOutPath</key>
+  <string>${escapeXml(input.paths.stdoutLogPath)}</string>
+  <key>StandardErrorPath</key>
+  <string>${escapeXml(input.paths.stderrLogPath)}</string>
+</dict>
+</plist>
+`;
+}
+
+export function planBridgeInstall(input: BridgeLaunchAgentInput): BridgeInstallPlan {
+  requireInstallInput(input);
+  const service = `gui/${input.uid}/${CLI_BRIDGE_LAUNCH_AGENT_LABEL}`;
+  return {
+    plistPath: input.paths.launchAgentPath,
+    plist: renderBridgeLaunchAgent(input),
+    bootoutArgs: ['bootout', service],
+    bootstrapArgs: ['bootstrap', `gui/${input.uid}`, input.paths.launchAgentPath],
+    kickstartArgs: ['kickstart', '-k', service],
+  };
+}
+
+export function planBridgeUninstall(
+  input: Pick<BridgeLaunchAgentInput, 'platform' | 'uid' | 'paths'>,
+): BridgeUninstallPlan {
+  if (input.platform !== 'darwin') {
+    throw new Error('MarkuprPlus CLI Bridge installation is supported only on macOS.');
+  }
+  return {
+    bootoutArgs: ['bootout', `gui/${input.uid}/${CLI_BRIDGE_LAUNCH_AGENT_LABEL}`],
+    filesToRemove: [input.paths.launchAgentPath, input.paths.configPath],
+  };
+}
+
+export async function runLaunchctl(args: string[]): Promise<LaunchctlResult> {
+  return new Promise((resolve, reject) => {
+    const child = spawn('/bin/launchctl', args, {
+      stdio: ['ignore', 'pipe', 'pipe'],
+      shell: false,
+    });
+    const stdout: Buffer[] = [];
+    const stderr: Buffer[] = [];
+    child.stdout.on('data', (chunk) => stdout.push(Buffer.from(chunk)));
+    child.stderr.on('data', (chunk) => stderr.push(Buffer.from(chunk)));
+    child.once('error', reject);
+    child.once('close', (exitCode) => resolve({
+      exitCode,
+      stdout: Buffer.concat(stdout).toString('utf8'),
+      stderr: Buffer.concat(stderr).toString('utf8'),
+    }));
+  });
+}
+
+async function refuseSymlink(path: string): Promise<void> {
+  try {
+    const details = await lstat(path);
+    if (details.isSymbolicLink()) {
+      throw new Error(`Refusing to replace symbolic link: ${path}`);
+    }
+  } catch (error) {
+    if (error instanceof Error && 'code' in error && error.code === 'ENOENT') return;
+    throw error;
+  }
+}
+
+export async function installBridgeLaunchAgent(
+  input: BridgeLaunchAgentInput,
+  run: LaunchctlRunner = runLaunchctl,
+): Promise<void> {
+  const plan = planBridgeInstall(input);
+  await mkdir(dirname(plan.plistPath), { recursive: true, mode: 0o700 });
+  await refuseSymlink(plan.plistPath);
+  await writeFile(plan.plistPath, plan.plist, { encoding: 'utf8', mode: 0o600 });
+  await run(plan.bootoutArgs).catch(() => ({ exitCode: 1, stdout: '', stderr: '' }));
+  const bootstrapped = await run(plan.bootstrapArgs);
+  if (bootstrapped.exitCode !== 0) {
+    throw new Error('Unable to bootstrap MarkuprPlus CLI Bridge.');
+  }
+}
+
+export async function startBridgeLaunchAgent(
+  input: BridgeLaunchAgentInput,
+  run: LaunchctlRunner = runLaunchctl,
+): Promise<void> {
+  const plan = planBridgeInstall(input);
+  const bootstrap = await run(plan.bootstrapArgs);
+  if (bootstrap.exitCode !== 0) {
+    const kickstart = await run(plan.kickstartArgs);
+    if (kickstart.exitCode !== 0) {
+      throw new Error('Unable to start MarkuprPlus CLI Bridge.');
+    }
+  }
+}
+
+export async function stopBridgeLaunchAgent(
+  input: Pick<BridgeLaunchAgentInput, 'platform' | 'uid' | 'paths'>,
+  run: LaunchctlRunner = runLaunchctl,
+): Promise<void> {
+  const result = await run(planBridgeUninstall(input).bootoutArgs);
+  if (result.exitCode !== 0) {
+    throw new Error('MarkuprPlus CLI Bridge is not running.');
+  }
+}
+
+export async function bridgeLaunchAgentRunning(
+  input: Pick<BridgeLaunchAgentInput, 'platform' | 'uid' | 'paths'>,
+  run: LaunchctlRunner = runLaunchctl,
+): Promise<boolean> {
+  const service = `gui/${input.uid}/${CLI_BRIDGE_LAUNCH_AGENT_LABEL}`;
+  return (await run(['print', service])).exitCode === 0;
+}
+
+export async function uninstallBridgeLaunchAgent(
+  input: Pick<BridgeLaunchAgentInput, 'platform' | 'uid' | 'paths'>,
+  run: LaunchctlRunner = runLaunchctl,
+): Promise<void> {
+  const plan = planBridgeUninstall(input);
+  await run(plan.bootoutArgs).catch(() => ({ exitCode: 1, stdout: '', stderr: '' }));
+  for (const path of plan.filesToRemove) {
+    await refuseSymlink(path);
+    await unlink(path).catch((error) => {
+      if (!(error instanceof Error && 'code' in error && error.code === 'ENOENT')) throw error;
+    });
+  }
+}

--- a/src/bridge/BridgeProviderRegistry.ts
+++ b/src/bridge/BridgeProviderRegistry.ts
@@ -1,0 +1,49 @@
+import type { AnalysisProviderStatus } from '../shared/types';
+import type { CliBridgeProvider } from '../shared/cliBridgeProtocol';
+import { CodexAnalyzer } from '../main/ai/CodexAnalyzer';
+import { codexCliDiscovery } from '../main/ai/CodexCliDiscovery';
+import { ClaudeCliAnalyzer } from '../main/ai/providers/ClaudeCliAnalyzer';
+import { claudeCliDiscovery } from '../main/ai/providers/ClaudeCliDiscovery';
+import {
+  CLI_PROVIDER_PROFILES,
+  ProfiledCliProvider,
+} from '../main/ai/providers/ProfiledCliProvider';
+import type { AnalysisProviderAdapter } from '../main/ai/providers/types';
+
+export interface BridgeProviderRegistry {
+  discoverAll(forceRefresh?: boolean): Promise<AnalysisProviderStatus[]>;
+  get(provider: CliBridgeProvider): AnalysisProviderAdapter;
+}
+
+export function createBridgeProviderRegistry(): BridgeProviderRegistry {
+  const codexAnalyzer = new CodexAnalyzer();
+  const claudeAnalyzer = new ClaudeCliAnalyzer();
+  const adapters: AnalysisProviderAdapter[] = [
+    {
+      id: 'codex-cli',
+      name: 'Codex CLI',
+      connection: 'cli',
+      discover: (forceRefresh) => codexCliDiscovery.discover(forceRefresh),
+      analyze: (session, modelId) => codexAnalyzer.analyze(session, modelId),
+    },
+    {
+      id: 'claude-cli',
+      name: 'Claude Code CLI',
+      connection: 'cli',
+      discover: (forceRefresh) => claudeCliDiscovery.discover(forceRefresh),
+      analyze: (session, modelId) => claudeAnalyzer.analyze(session, modelId),
+    },
+    ...CLI_PROVIDER_PROFILES.map((profile) => new ProfiledCliProvider(profile)),
+  ];
+  const byId = new Map(adapters.map((adapter) => [adapter.id, adapter]));
+  return {
+    discoverAll: (forceRefresh = false) => Promise.all(
+      adapters.map((adapter) => adapter.discover(forceRefresh)),
+    ),
+    get(provider) {
+      const adapter = byId.get(provider);
+      if (!adapter) throw new Error(`Unsupported analysis provider: ${provider}`);
+      return adapter;
+    },
+  };
+}

--- a/src/bridge/BridgeSession.ts
+++ b/src/bridge/BridgeSession.ts
@@ -1,0 +1,85 @@
+import type { Session, Screenshot } from '../main/SessionController';
+import type { MarkedIssuePayload, SessionMetadata } from '../shared/types';
+import {
+  parseBridgeSessionPayload,
+  type BridgeSessionPayload,
+} from '../shared/cliBridgeProtocol';
+
+function screenshotMimeType(buffer: Buffer): 'image/png' | 'image/jpeg' {
+  if (
+    buffer.length >= 3
+    && buffer[0] === 0xff
+    && buffer[1] === 0xd8
+    && buffer[2] === 0xff
+  ) {
+    return 'image/jpeg';
+  }
+  return 'image/png';
+}
+
+function sanitizeMarkedIssues(
+  issues: MarkedIssuePayload[] | undefined,
+): BridgeSessionPayload['metadata']['markedIssues'] {
+  return issues?.map(({ screenshotPath: _screenshotPath, ...issue }) => structuredClone(issue));
+}
+
+function sanitizeMetadata(metadata: SessionMetadata): BridgeSessionPayload['metadata'] {
+  const {
+    recordingPath: _recordingPath,
+    audioPath: _audioPath,
+    markedIssues,
+    ...portable
+  } = metadata;
+  return {
+    ...structuredClone(portable),
+    ...(markedIssues ? { markedIssues: sanitizeMarkedIssues(markedIssues) } : {}),
+  };
+}
+
+export function serializeBridgeSession(session: Session): BridgeSessionPayload {
+  return parseBridgeSessionPayload({
+    id: session.id,
+    startTime: session.startTime,
+    ...(session.endTime === undefined ? {} : { endTime: session.endTime }),
+    state: session.state,
+    sourceId: session.sourceId,
+    feedbackItems: session.feedbackItems.map(({ id, timestamp, text, confidence }) => ({
+      id,
+      timestamp,
+      text,
+      confidence,
+    })),
+    transcriptBuffer: structuredClone(session.transcriptBuffer),
+    screenshots: session.screenshotBuffer.map((screenshot) => ({
+      id: screenshot.id,
+      timestamp: screenshot.timestamp,
+      width: screenshot.width,
+      height: screenshot.height,
+      mimeType: screenshotMimeType(screenshot.buffer),
+      dataBase64: screenshot.buffer.toString('base64'),
+    })),
+    metadata: sanitizeMetadata(session.metadata),
+  });
+}
+
+export function deserializeBridgeSession(value: BridgeSessionPayload): Session {
+  const payload = parseBridgeSessionPayload(value);
+  const screenshotBuffer: Screenshot[] = payload.screenshots.map((screenshot) => ({
+    id: screenshot.id,
+    timestamp: screenshot.timestamp,
+    width: screenshot.width,
+    height: screenshot.height,
+    buffer: Buffer.from(screenshot.dataBase64, 'base64'),
+  }));
+  return {
+    id: payload.id,
+    startTime: payload.startTime,
+    ...(payload.endTime === undefined ? {} : { endTime: payload.endTime }),
+    state: payload.state,
+    sourceId: payload.sourceId,
+    feedbackItems: structuredClone(payload.feedbackItems),
+    transcriptBuffer: structuredClone(payload.transcriptBuffer),
+    screenshotBuffer,
+    metadata: structuredClone(payload.metadata) as SessionMetadata,
+  };
+}

--- a/src/bridge/BridgeSession.ts
+++ b/src/bridge/BridgeSession.ts
@@ -24,14 +24,13 @@ function sanitizeMarkedIssues(
 }
 
 function sanitizeMetadata(metadata: SessionMetadata): BridgeSessionPayload['metadata'] {
-  const {
-    recordingPath: _recordingPath,
-    audioPath: _audioPath,
-    markedIssues,
-    ...portable
-  } = metadata;
+  const portable = structuredClone(metadata);
+  const { markedIssues } = portable;
+  delete portable.recordingPath;
+  delete portable.audioPath;
+  delete portable.markedIssues;
   return {
-    ...structuredClone(portable),
+    ...portable,
     ...(markedIssues ? { markedIssues: sanitizeMarkedIssues(markedIssues) } : {}),
   };
 }

--- a/src/bridge/CliBridgeServer.ts
+++ b/src/bridge/CliBridgeServer.ts
@@ -1,6 +1,6 @@
 import { createServer, type IncomingMessage, type Server, type ServerResponse } from 'node:http';
 import type { AddressInfo } from 'node:net';
-import type { AnalysisProviderRegistry } from '../main/ai/providers/AnalysisProviderRegistry';
+import type { BridgeProviderRegistry } from './BridgeProviderRegistry';
 import { deserializeBridgeSession } from './BridgeSession';
 import { isAuthorized } from './BridgeAuth';
 import { BridgeHttpError, sanitizeBridgeMessage } from './BridgeErrors';
@@ -20,7 +20,7 @@ const DEFAULT_ANALYSIS_TIMEOUT_MS = 190_000;
 export interface CliBridgeServerOptions {
   token: string;
   bridgeVersion: string;
-  registry: AnalysisProviderRegistry;
+  registry: BridgeProviderRegistry;
   host?: string;
   port?: number;
   maxBodyBytes?: number;

--- a/src/bridge/CliBridgeServer.ts
+++ b/src/bridge/CliBridgeServer.ts
@@ -1,0 +1,299 @@
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from 'node:http';
+import type { AddressInfo } from 'node:net';
+import type { AnalysisProviderRegistry } from '../main/ai/providers/AnalysisProviderRegistry';
+import { deserializeBridgeSession } from './BridgeSession';
+import { isAuthorized } from './BridgeAuth';
+import { BridgeHttpError, sanitizeBridgeMessage } from './BridgeErrors';
+import {
+  CLI_BRIDGE_DEFAULT_HOST,
+  CLI_BRIDGE_DEFAULT_PORT,
+  CLI_BRIDGE_MAX_BODY_BYTES,
+  CLI_BRIDGE_PROTOCOL_VERSION,
+  isCliBridgeProvider,
+  parseBridgeAnalyzeRequest,
+  type BridgeErrorEnvelope,
+  type CliBridgeErrorCode,
+} from '../shared/cliBridgeProtocol';
+
+const DEFAULT_ANALYSIS_TIMEOUT_MS = 190_000;
+
+export interface CliBridgeServerOptions {
+  token: string;
+  bridgeVersion: string;
+  registry: AnalysisProviderRegistry;
+  host?: string;
+  port?: number;
+  maxBodyBytes?: number;
+  analysisTimeoutMs?: number;
+}
+
+export interface CliBridgeServerHandle {
+  server: Server;
+  origin: string;
+  port: number;
+  close(): Promise<void>;
+}
+
+function json(
+  response: ServerResponse,
+  status: number,
+  value: unknown,
+  extraHeaders: Record<string, string> = {},
+): void {
+  const body = JSON.stringify(value);
+  response.writeHead(status, {
+    'Content-Type': 'application/json; charset=utf-8',
+    'Content-Length': String(Buffer.byteLength(body)),
+    'Cache-Control': 'no-store',
+    'X-Content-Type-Options': 'nosniff',
+    ...extraHeaders,
+  });
+  response.end(body);
+}
+
+function bridgeError(
+  response: ServerResponse,
+  status: number,
+  code: CliBridgeErrorCode,
+  message: string,
+): void {
+  const body: BridgeErrorEnvelope = { error: { code, message } };
+  json(response, status, body);
+}
+
+function currentPort(server: Server): number | null {
+  const address = server.address();
+  return address && typeof address !== 'string' ? address.port : null;
+}
+
+function hasAllowedHost(request: IncomingMessage, server: Server): boolean {
+  const host = request.headers.host;
+  const port = currentPort(server);
+  if (!host || port === null) return false;
+  return host === `127.0.0.1:${port}` || host === `localhost:${port}`;
+}
+
+function hasLoopbackPeer(request: IncomingMessage): boolean {
+  const address = request.socket.remoteAddress;
+  return address === '127.0.0.1' || address === '::ffff:127.0.0.1';
+}
+
+async function readJsonBody(request: IncomingMessage, maxBytes: number): Promise<unknown> {
+  if (!request.headers['content-type']?.toLowerCase().startsWith('application/json')) {
+    throw new BridgeHttpError(400, 'INVALID_REQUEST', 'Content-Type must be application/json.');
+  }
+  const chunks: Buffer[] = [];
+  let bytes = 0;
+  let tooLarge = false;
+  for await (const rawChunk of request) {
+    const chunk = Buffer.isBuffer(rawChunk) ? rawChunk : Buffer.from(rawChunk);
+    bytes += chunk.length;
+    if (bytes > maxBytes) {
+      tooLarge = true;
+      continue;
+    }
+    chunks.push(chunk);
+  }
+  if (tooLarge) {
+    throw new BridgeHttpError(
+      413,
+      'PAYLOAD_TOO_LARGE',
+      'Bridge request exceeds the allowed size.',
+    );
+  }
+  try {
+    return JSON.parse(Buffer.concat(chunks).toString('utf8')) as unknown;
+  } catch {
+    throw new BridgeHttpError(400, 'INVALID_REQUEST', 'Bridge request must contain valid JSON.');
+  }
+}
+
+function providerFromPath(pathname: string): {
+  provider: string;
+  action: 'test' | 'models';
+} | null {
+  const match = /^\/v1\/providers\/([^/]+)\/(test|models)$/.exec(pathname);
+  if (!match) return null;
+  return { provider: decodeURIComponent(match[1]), action: match[2] as 'test' | 'models' };
+}
+
+function timeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const handle = setTimeout(() => {
+      reject(new BridgeHttpError(504, 'ANALYSIS_TIMEOUT', 'CLI analysis timed out.'));
+    }, timeoutMs);
+    promise.then(
+      (value) => {
+        clearTimeout(handle);
+        resolve(value);
+      },
+      (error) => {
+        clearTimeout(handle);
+        reject(error);
+      },
+    );
+  });
+}
+
+export function createCliBridgeServer(options: CliBridgeServerOptions): Server {
+  const maxBodyBytes = options.maxBodyBytes ?? CLI_BRIDGE_MAX_BODY_BYTES;
+  const analysisTimeoutMs = options.analysisTimeoutMs ?? DEFAULT_ANALYSIS_TIMEOUT_MS;
+  let analysisActive = false;
+
+  const server = createServer(async (request, response) => {
+    try {
+      if (!hasLoopbackPeer(request) || !hasAllowedHost(request, server)) {
+        throw new BridgeHttpError(400, 'INVALID_REQUEST', 'Invalid bridge request origin.');
+      }
+
+      const url = new URL(request.url || '/', 'http://127.0.0.1');
+      if (url.pathname === '/v1/health') {
+        if (request.method !== 'GET') {
+          throw new BridgeHttpError(405, 'METHOD_NOT_ALLOWED', 'Method not allowed.');
+        }
+        json(response, 200, {
+          bridgeVersion: options.bridgeVersion,
+          protocolVersion: CLI_BRIDGE_PROTOCOL_VERSION,
+          pairingConfigured: options.token.length > 0,
+        });
+        return;
+      }
+
+      const authorization = request.headers.authorization;
+      if (!authorization) {
+        throw new BridgeHttpError(401, 'AUTH_REQUIRED', 'Bridge authentication is required.');
+      }
+      if (!isAuthorized(authorization, options.token)) {
+        throw new BridgeHttpError(401, 'AUTH_INVALID', 'Bridge authentication failed.');
+      }
+
+      if (url.pathname === '/v1/providers') {
+        if (request.method !== 'GET') {
+          throw new BridgeHttpError(405, 'METHOD_NOT_ALLOWED', 'Method not allowed.');
+        }
+        const providers = await options.registry.discoverAll(url.searchParams.get('force') === 'true');
+        json(response, 200, {
+          protocolVersion: CLI_BRIDGE_PROTOCOL_VERSION,
+          providers,
+        });
+        return;
+      }
+
+      const providerRoute = providerFromPath(url.pathname);
+      if (providerRoute) {
+        if (!isCliBridgeProvider(providerRoute.provider)) {
+          throw new BridgeHttpError(400, 'PROVIDER_UNSUPPORTED', 'Unsupported CLI provider.');
+        }
+        const adapter = options.registry.get(providerRoute.provider);
+        if (providerRoute.action === 'test') {
+          if (request.method !== 'POST') {
+            throw new BridgeHttpError(405, 'METHOD_NOT_ALLOWED', 'Method not allowed.');
+          }
+          json(response, 200, await adapter.discover(true));
+          return;
+        }
+        if (request.method !== 'GET') {
+          throw new BridgeHttpError(405, 'METHOD_NOT_ALLOWED', 'Method not allowed.');
+        }
+        const status = await adapter.discover(false);
+        json(response, 200, {
+          protocolVersion: CLI_BRIDGE_PROTOCOL_VERSION,
+          models: status.models || [],
+        });
+        return;
+      }
+
+      if (url.pathname === '/v1/analyze') {
+        if (request.method !== 'POST') {
+          throw new BridgeHttpError(405, 'METHOD_NOT_ALLOWED', 'Method not allowed.');
+        }
+        if (analysisActive) {
+          throw new BridgeHttpError(429, 'BRIDGE_BUSY', 'The CLI bridge is already analyzing a report.');
+        }
+        const raw = await readJsonBody(request, maxBodyBytes);
+        let parsed;
+        try {
+          parsed = parseBridgeAnalyzeRequest(raw);
+        } catch (error) {
+          const unsupported = error instanceof Error && /unsupported provider/i.test(error.message);
+          throw new BridgeHttpError(
+            400,
+            unsupported ? 'PROVIDER_UNSUPPORTED' : 'INVALID_REQUEST',
+            unsupported ? 'Unsupported CLI provider.' : 'Invalid bridge analysis request.',
+          );
+        }
+
+        analysisActive = true;
+        try {
+          const adapter = options.registry.get(parsed.provider);
+          const status = await adapter.discover(false);
+          if (!status.ready) {
+            throw new BridgeHttpError(
+              503,
+              'PROVIDER_UNAVAILABLE',
+              sanitizeBridgeMessage(status.diagnostic, `${adapter.name} is unavailable.`),
+            );
+          }
+          const analysis = await timeout(
+            adapter.analyze(
+              deserializeBridgeSession(parsed.session),
+              parsed.modelId,
+            ),
+            analysisTimeoutMs,
+          );
+          if (!analysis) {
+            throw new BridgeHttpError(502, 'ANALYSIS_FAILED', 'CLI analysis returned no result.');
+          }
+          json(response, 200, {
+            protocolVersion: CLI_BRIDGE_PROTOCOL_VERSION,
+            analysis,
+          });
+        } catch (error) {
+          if (error instanceof BridgeHttpError) throw error;
+          throw new BridgeHttpError(
+            502,
+            'ANALYSIS_FAILED',
+            sanitizeBridgeMessage(error, 'CLI analysis failed.'),
+          );
+        } finally {
+          analysisActive = false;
+        }
+        return;
+      }
+
+      throw new BridgeHttpError(404, 'NOT_FOUND', 'Bridge endpoint not found.');
+    } catch (error) {
+      if (error instanceof BridgeHttpError) {
+        bridgeError(response, error.status, error.code, error.message);
+        return;
+      }
+      bridgeError(response, 500, 'INTERNAL_ERROR', 'The CLI bridge encountered an internal error.');
+    }
+  });
+
+  return server;
+}
+
+export async function startCliBridgeServer(
+  options: CliBridgeServerOptions,
+): Promise<CliBridgeServerHandle> {
+  const server = createCliBridgeServer(options);
+  const host = options.host ?? CLI_BRIDGE_DEFAULT_HOST;
+  const port = options.port ?? CLI_BRIDGE_DEFAULT_PORT;
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(port, host, () => {
+      server.off('error', reject);
+      resolve();
+    });
+  });
+  const address = server.address() as AddressInfo;
+  return {
+    server,
+    port: address.port,
+    origin: `http://${host}:${address.port}`,
+    close: () => new Promise<void>((resolve, reject) => {
+      server.close((error) => error ? reject(error) : resolve());
+    }),
+  };
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -30,6 +30,7 @@ import { runDoctorChecks } from './doctor';
 import { runInit, CONFIG_FILENAME } from './init';
 import { templateRegistry } from '../main/output/templates/index';
 import { PUBLIC_BRAND_NAME } from '../shared/publicBrand';
+import { registerBridgeCommand } from '../bridge/BridgeCommand';
 
 // Read version from package.json at build time (injected by esbuild)
 declare const __MARKUPRX_VERSION__: string;
@@ -219,6 +220,8 @@ program
       activePipeline = null;
     }
   });
+
+registerBridgeCommand(program, { bridgeVersion: VERSION });
 
 // ============================================================================
 // watch command
@@ -572,4 +575,4 @@ if (process.argv.length <= 2) {
   process.exit(EXIT_SUCCESS);
 }
 
-program.parse();
+await program.parseAsync();

--- a/src/main/ai/bridge/BridgeCliProvider.ts
+++ b/src/main/ai/bridge/BridgeCliProvider.ts
@@ -1,0 +1,74 @@
+import type { Session } from '../../SessionController';
+import type { AIAnalysisResult } from '../types';
+import type { AnalysisProviderStatus } from '../../../shared/types';
+import type { CliBridgeProvider } from '../../../shared/cliBridgeProtocol';
+import type { AnalysisProviderAdapter } from '../providers/types';
+import { CliBridgeClient, CliBridgeClientError } from './CliBridgeClient';
+
+export const BRIDGE_CLI_PROVIDER_NAMES: Record<CliBridgeProvider, string> = {
+  'codex-cli': 'Codex CLI',
+  'claude-cli': 'Claude Code CLI',
+  'opencode-cli': 'OpenCode',
+  'cursor-cli': 'Cursor Agent CLI',
+  'qwen-cli': 'Qwen Code',
+  'goose-cli': 'Goose',
+  'amp-cli': 'Amp',
+  'kiro-cli': 'Kiro CLI',
+  'aider-cli': 'Aider',
+};
+
+function diagnosticFor(error: unknown): string {
+  if (error instanceof CliBridgeClientError) {
+    if (error.code === 'BRIDGE_NOT_PAIRED' || error.code === 'AUTH_REQUIRED' || error.code === 'AUTH_INVALID') {
+      return 'Pair MarkuprPlus CLI Bridge in Advanced Settings.';
+    }
+    if (error.code === 'BRIDGE_OFFLINE') {
+      return 'Start MarkuprPlus CLI Bridge, then scan again.';
+    }
+    if (error.code === 'BRIDGE_INCOMPATIBLE') {
+      return 'Update MarkuprPlus CLI Bridge, then pair again.';
+    }
+    return error.message;
+  }
+  return 'MarkuprPlus CLI Bridge is unavailable.';
+}
+
+export class BridgeCliProvider implements AnalysisProviderAdapter {
+  readonly connection = 'cli' as const;
+
+  constructor(
+    readonly id: CliBridgeProvider,
+    readonly name: string,
+    private readonly client: CliBridgeClient,
+  ) {}
+
+  async discover(forceRefresh = false): Promise<AnalysisProviderStatus> {
+    try {
+      if (forceRefresh) return await this.client.testProvider(this.id);
+      const status = (await this.client.discoverProviders(false))
+        .find((candidate) => candidate.id === this.id);
+      if (!status) {
+        throw new CliBridgeClientError(
+          'BRIDGE_PROTOCOL_ERROR',
+          `${this.name} was not returned by MarkuprPlus CLI Bridge.`,
+        );
+      }
+      return status;
+    } catch (error) {
+      return {
+        id: this.id,
+        name: this.name,
+        connection: 'cli',
+        installed: false,
+        authenticated: false,
+        ready: false,
+        models: [],
+        diagnostic: diagnosticFor(error),
+      };
+    }
+  }
+
+  analyze(session: Session, modelId?: string): Promise<AIAnalysisResult> {
+    return this.client.analyze(this.id, session, modelId);
+  }
+}

--- a/src/main/ai/bridge/CliBridgeClient.ts
+++ b/src/main/ai/bridge/CliBridgeClient.ts
@@ -1,0 +1,255 @@
+import type { Session } from '../../SessionController';
+import type { AIAnalysisResult } from '../types';
+import type { AnalysisModelOption, AnalysisProviderStatus } from '../../../shared/types';
+import {
+  CLI_BRIDGE_DEFAULT_HOST,
+  CLI_BRIDGE_DEFAULT_PORT,
+  CLI_BRIDGE_PROTOCOL_VERSION,
+  type BridgeHealthResponse,
+  type CliBridgeErrorCode,
+  type CliBridgeProvider,
+} from '../../../shared/cliBridgeProtocol';
+import { serializeBridgeSession } from '../../../bridge/BridgeSession';
+import { parseAnalysisResult } from '../analysisContract';
+
+const DEFAULT_BASE_URL = `http://${CLI_BRIDGE_DEFAULT_HOST}:${CLI_BRIDGE_DEFAULT_PORT}`;
+const DEFAULT_DISCOVERY_TIMEOUT_MS = 2_000;
+const DEFAULT_ANALYSIS_TIMEOUT_MS = 190_000;
+
+export type CliBridgeClientErrorCode =
+  | CliBridgeErrorCode
+  | 'BRIDGE_NOT_PAIRED'
+  | 'BRIDGE_OFFLINE'
+  | 'BRIDGE_INCOMPATIBLE';
+
+export class CliBridgeClientError extends Error {
+  constructor(
+    public readonly code: CliBridgeClientErrorCode,
+    message: string,
+    public readonly status?: number,
+  ) {
+    super(message);
+    this.name = 'CliBridgeClientError';
+  }
+}
+
+export interface CliBridgeClientOptions {
+  getToken(): Promise<string | null>;
+  baseUrl?: string;
+  fetchFn?: typeof fetch;
+  discoveryTimeoutMs?: number;
+  analysisTimeoutMs?: number;
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+function requireProtocol(value: unknown): Record<string, unknown> {
+  if (!isObject(value) || value.protocolVersion !== CLI_BRIDGE_PROTOCOL_VERSION) {
+    throw new CliBridgeClientError(
+      'BRIDGE_INCOMPATIBLE',
+      `Update MarkuprPlus CLI Bridge; protocol ${CLI_BRIDGE_PROTOCOL_VERSION} is required.`,
+    );
+  }
+  return value;
+}
+
+function requireProviderStatus(value: unknown): AnalysisProviderStatus {
+  if (
+    !isObject(value)
+    || typeof value.id !== 'string'
+    || typeof value.name !== 'string'
+    || typeof value.installed !== 'boolean'
+    || typeof value.ready !== 'boolean'
+  ) {
+    throw new CliBridgeClientError('BRIDGE_PROTOCOL_ERROR', 'The CLI bridge returned an invalid provider status.');
+  }
+  return value as unknown as AnalysisProviderStatus;
+}
+
+export class CliBridgeClient {
+  private readonly options: Required<Omit<CliBridgeClientOptions, 'getToken'>>
+    & Pick<CliBridgeClientOptions, 'getToken'>;
+  private cachedProviders: AnalysisProviderStatus[] | null = null;
+  private discoveryPromise: Promise<AnalysisProviderStatus[]> | null = null;
+
+  constructor(options: CliBridgeClientOptions) {
+    this.options = {
+      getToken: options.getToken,
+      baseUrl: options.baseUrl || DEFAULT_BASE_URL,
+      fetchFn: options.fetchFn || fetch,
+      discoveryTimeoutMs: options.discoveryTimeoutMs ?? DEFAULT_DISCOVERY_TIMEOUT_MS,
+      analysisTimeoutMs: options.analysisTimeoutMs ?? DEFAULT_ANALYSIS_TIMEOUT_MS,
+    };
+  }
+
+  async getHealth(): Promise<BridgeHealthResponse> {
+    const value = await this.requestJson('/v1/health', {
+      method: 'GET',
+      timeoutMs: this.options.discoveryTimeoutMs,
+      authenticated: false,
+    });
+    if (
+      !isObject(value)
+      || typeof value.bridgeVersion !== 'string'
+      || typeof value.pairingConfigured !== 'boolean'
+      || value.protocolVersion !== CLI_BRIDGE_PROTOCOL_VERSION
+    ) {
+      requireProtocol(value);
+      throw new CliBridgeClientError('BRIDGE_PROTOCOL_ERROR', 'The CLI bridge returned an invalid health response.');
+    }
+    return value as unknown as BridgeHealthResponse;
+  }
+
+  async discoverProviders(
+    forceRefresh = false,
+    tokenOverride?: string,
+  ): Promise<AnalysisProviderStatus[]> {
+    if (!forceRefresh && !tokenOverride && this.cachedProviders) return this.cachedProviders;
+    if (!forceRefresh && !tokenOverride && this.discoveryPromise) return this.discoveryPromise;
+    const operation = this.loadProviders(forceRefresh, tokenOverride);
+    if (!forceRefresh && !tokenOverride) this.discoveryPromise = operation;
+    try {
+      const providers = await operation;
+      if (!tokenOverride) this.cachedProviders = providers;
+      return providers;
+    } finally {
+      if (!forceRefresh && !tokenOverride) this.discoveryPromise = null;
+    }
+  }
+
+  private async loadProviders(
+    forceRefresh: boolean,
+    tokenOverride?: string,
+  ): Promise<AnalysisProviderStatus[]> {
+    const value = requireProtocol(await this.requestJson(
+      `/v1/providers?force=${forceRefresh ? 'true' : 'false'}`,
+      {
+        method: 'GET',
+        timeoutMs: this.options.discoveryTimeoutMs,
+        authenticated: true,
+        tokenOverride,
+      },
+    ));
+    if (!Array.isArray(value.providers)) {
+      throw new CliBridgeClientError('BRIDGE_PROTOCOL_ERROR', 'The CLI bridge returned invalid providers.');
+    }
+    return value.providers.map(requireProviderStatus);
+  }
+
+  async testProvider(provider: CliBridgeProvider): Promise<AnalysisProviderStatus> {
+    const value = await this.requestJson(`/v1/providers/${encodeURIComponent(provider)}/test`, {
+      method: 'POST',
+      timeoutMs: this.options.discoveryTimeoutMs,
+      authenticated: true,
+    });
+    this.cachedProviders = null;
+    return requireProviderStatus(value);
+  }
+
+  async models(provider: CliBridgeProvider): Promise<AnalysisModelOption[]> {
+    const value = requireProtocol(await this.requestJson(
+      `/v1/providers/${encodeURIComponent(provider)}/models`,
+      {
+        method: 'GET',
+        timeoutMs: this.options.discoveryTimeoutMs,
+        authenticated: true,
+      },
+    ));
+    if (!Array.isArray(value.models)) {
+      throw new CliBridgeClientError('BRIDGE_PROTOCOL_ERROR', 'The CLI bridge returned invalid models.');
+    }
+    return value.models as AnalysisModelOption[];
+  }
+
+  async analyze(
+    provider: CliBridgeProvider,
+    session: Session,
+    modelId?: string,
+  ): Promise<AIAnalysisResult> {
+    const value = requireProtocol(await this.requestJson('/v1/analyze', {
+      method: 'POST',
+      timeoutMs: this.options.analysisTimeoutMs,
+      authenticated: true,
+      body: {
+        protocolVersion: CLI_BRIDGE_PROTOCOL_VERSION,
+        provider,
+        ...(modelId?.trim() ? { modelId: modelId.trim() } : {}),
+        session: serializeBridgeSession(session),
+      },
+    }));
+    if (!isObject(value.analysis)) {
+      throw new CliBridgeClientError('BRIDGE_PROTOCOL_ERROR', 'The CLI bridge returned invalid analysis.');
+    }
+    try {
+      return parseAnalysisResult(JSON.stringify(value.analysis));
+    } catch {
+      throw new CliBridgeClientError('BRIDGE_PROTOCOL_ERROR', 'The CLI bridge returned invalid analysis.');
+    }
+  }
+
+  private async requestJson(
+    path: string,
+    request: {
+      method: 'GET' | 'POST';
+      timeoutMs: number;
+      authenticated: boolean;
+      tokenOverride?: string;
+      body?: unknown;
+    },
+  ): Promise<unknown> {
+    let token: string | null = null;
+    if (request.authenticated) {
+      token = request.tokenOverride ?? await this.options.getToken();
+      if (!token) {
+        throw new CliBridgeClientError('BRIDGE_NOT_PAIRED', 'Pair MarkuprPlus CLI Bridge.');
+      }
+    }
+    const controller = new AbortController();
+    const timeoutHandle = setTimeout(() => controller.abort(), request.timeoutMs);
+    try {
+      const response = await this.options.fetchFn(`${this.options.baseUrl}${path}`, {
+        method: request.method,
+        headers: {
+          ...(token ? { Authorization: `Bearer ${token}` } : {}),
+          ...(request.body === undefined ? {} : { 'Content-Type': 'application/json' }),
+        },
+        ...(request.body === undefined ? {} : { body: JSON.stringify(request.body) }),
+        signal: controller.signal,
+      });
+      const text = await response.text();
+      let value: unknown;
+      try {
+        value = JSON.parse(text) as unknown;
+      } catch {
+        throw new CliBridgeClientError(
+          'BRIDGE_PROTOCOL_ERROR',
+          'The CLI bridge returned an invalid response.',
+          response.status,
+        );
+      }
+      if (!response.ok) {
+        const error = isObject(value) && isObject(value.error) ? value.error : null;
+        const code = error && typeof error.code === 'string'
+          ? error.code as CliBridgeClientErrorCode
+          : 'BRIDGE_PROTOCOL_ERROR';
+        const message = error && typeof error.message === 'string'
+          ? error.message
+          : 'The CLI bridge request failed.';
+        throw new CliBridgeClientError(code, message.slice(0, 500), response.status);
+      }
+      return value;
+    } catch (error) {
+      if (error instanceof CliBridgeClientError) throw error;
+      throw new CliBridgeClientError(
+        'BRIDGE_OFFLINE',
+        error instanceof Error && error.name === 'AbortError'
+          ? 'Start MarkuprPlus CLI Bridge; the connection timed out.'
+          : 'Start MarkuprPlus CLI Bridge.',
+      );
+    } finally {
+      clearTimeout(timeoutHandle);
+    }
+  }
+}

--- a/src/main/ai/index.ts
+++ b/src/main/ai/index.ts
@@ -8,6 +8,8 @@ export { processSession } from './AIPipelineManager';
 export { CodexAnalyzer, CodexCliError } from './CodexAnalyzer';
 export { CodexCliDiscovery, codexCliDiscovery } from './CodexCliDiscovery';
 export { runCliProcess } from './CliProcessRunner';
+export { CliBridgeClient, CliBridgeClientError } from './bridge/CliBridgeClient';
+export { BridgeCliProvider } from './bridge/BridgeCliProvider';
 export {
   AnalysisProviderRegistry,
   createAnalysisProviderRegistry,

--- a/src/main/ai/providers/AnalysisProviderRegistry.ts
+++ b/src/main/ai/providers/AnalysisProviderRegistry.ts
@@ -13,8 +13,17 @@ import type {
 } from './types';
 import type { ISettingsManager } from '../../settings/SettingsManager';
 import { AnthropicApiProvider } from './AnthropicApiProvider';
-import { currentDistributionCapabilities } from '../../../shared/distribution';
+import {
+  currentDistribution,
+  type DistributionKind,
+} from '../../../shared/distribution';
 import { CLI_PROVIDER_PROFILES, ProfiledCliProvider } from './ProfiledCliProvider';
+import { CliBridgeClient } from '../bridge/CliBridgeClient';
+import {
+  BRIDGE_CLI_PROVIDER_NAMES,
+  BridgeCliProvider,
+} from '../bridge/BridgeCliProvider';
+import { CLI_BRIDGE_PROVIDER_IDS } from '../../../shared/cliBridgeProtocol';
 
 function profiledCliAdapters(): AnalysisProviderAdapter[] {
   return CLI_PROVIDER_PROFILES.map((profile) => new ProfiledCliProvider(profile));
@@ -94,11 +103,12 @@ export function createLocalAnalysisProviderRegistry(): AnalysisProviderRegistry 
 
 export function createDefaultAnalysisProviderRegistry(
   settingsManager: ISettingsManager,
-  allowCliProviders = currentDistributionCapabilities().externalCliProviders,
+  options: DefaultAnalysisProviderRegistryOptions = {},
 ): AnalysisProviderRegistry {
+  const distribution = options.distribution ?? currentDistribution();
   const codexAnalyzer = new CodexAnalyzer();
   const claudeAnalyzer = new ClaudeCliAnalyzer();
-  const cliAdapters: AnalysisProviderAdapter[] = allowCliProviders ? [
+  const directCliAdapters: AnalysisProviderAdapter[] = [
     {
       id: 'codex-cli',
       name: 'Codex CLI',
@@ -114,11 +124,24 @@ export function createDefaultAnalysisProviderRegistry(
       analyze: (session, modelId) => claudeAnalyzer.analyze(session, modelId),
     },
     ...profiledCliAdapters(),
-  ] : [];
+  ];
+  const bridgeClient = options.bridgeClient ?? new CliBridgeClient({
+    getToken: () => settingsManager.getApiKey('cli-bridge'),
+  });
+  const cliAdapters: AnalysisProviderAdapter[] = distribution === 'direct'
+    ? directCliAdapters
+    : CLI_BRIDGE_PROVIDER_IDS.map((id) => (
+        new BridgeCliProvider(id, BRIDGE_CLI_PROVIDER_NAMES[id], bridgeClient)
+      ));
   return new AnalysisProviderRegistry([
     ...cliAdapters,
     new OllamaProvider(),
     new LmStudioProvider(),
     new AnthropicApiProvider(settingsManager),
   ]);
+}
+
+export interface DefaultAnalysisProviderRegistryOptions {
+  distribution?: DistributionKind;
+  bridgeClient?: CliBridgeClient;
 }

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -115,6 +115,7 @@ import {
 import {
   attachFallbackFramesToMarkedIssues,
   captureContextsToKeyMoments,
+  removeClaimedTranscriptFrames,
   nearestCaptureContext,
 } from './pipeline/CaptureMomentHints';
 import { protectRendererNavigation } from './security/NavigationGuard';
@@ -1427,6 +1428,11 @@ async function stopSession(): Promise<{
       session.metadata.markedIssues = structuredClone(finalizedMarkedIssues);
       sessionController.setMarkedIssues(finalizedMarkedIssues);
       if (postProcessResult) {
+        postProcessResult.extractedFrames = removeClaimedTranscriptFrames(
+          postProcessResult.extractedFrames,
+          postProcessResult.transcriptSegments,
+          finalizedMarkedIssues,
+        );
         postProcessResult.markedIssues = structuredClone(finalizedMarkedIssues);
       }
       const ordinaryFrameCount = postProcessResult?.extractedFrames

--- a/src/main/ipc/cliBridgeHandlers.ts
+++ b/src/main/ipc/cliBridgeHandlers.ts
@@ -102,7 +102,7 @@ export function registerCliBridgeHandlers(
           success: false,
           status: notPairedStatus(
             Boolean(previousToken),
-            'Enter the 43-character token printed by markuprplus bridge token.',
+            'Enter the 43-character token printed by markuprx bridge token.',
           ),
         };
       }

--- a/src/main/ipc/cliBridgeHandlers.ts
+++ b/src/main/ipc/cliBridgeHandlers.ts
@@ -1,0 +1,134 @@
+import { ipcMain } from 'electron';
+import { CliBridgeClient, CliBridgeClientError } from '../ai/bridge/CliBridgeClient';
+import { currentDistribution, type DistributionKind } from '../../shared/distribution';
+import { CLI_BRIDGE_PROVIDER_IDS } from '../../shared/cliBridgeProtocol';
+import {
+  IPC_CHANNELS,
+  type CliBridgeConnectionStatus,
+  type CliBridgePairResult,
+} from '../../shared/types';
+import type { ISettingsManager } from '../settings/SettingsManager';
+import type { IpcContext } from './types';
+
+const BRIDGE_SECRET_SERVICE = 'cli-bridge';
+const BRIDGE_TOKEN_PATTERN = /^[A-Za-z0-9_-]{43}$/;
+
+interface PairingBridgeClient {
+  discoverProviders(forceRefresh?: boolean, tokenOverride?: string): ReturnType<CliBridgeClient['discoverProviders']>;
+}
+
+export interface CliBridgeHandlerDependencies {
+  distribution(): DistributionKind;
+  createClient(settingsManager: ISettingsManager): PairingBridgeClient;
+}
+
+const DEFAULT_DEPENDENCIES: CliBridgeHandlerDependencies = {
+  distribution: currentDistribution,
+  createClient: (settingsManager) => new CliBridgeClient({
+    getToken: () => settingsManager.getApiKey(BRIDGE_SECRET_SERVICE),
+  }),
+};
+
+function settingsFrom(ctx: IpcContext): ISettingsManager {
+  const settingsManager = ctx.getSettingsManager();
+  if (!settingsManager) throw new Error('Settings manager is unavailable');
+  return settingsManager;
+}
+
+function notApplicableStatus(): CliBridgeConnectionStatus {
+  return {
+    state: 'not-applicable',
+    paired: false,
+    diagnostic: 'CLI providers run directly in this build.',
+  };
+}
+
+function notPairedStatus(paired = false, diagnostic = 'Pair MarkuprPlus CLI Bridge.'):
+CliBridgeConnectionStatus {
+  return { state: 'not-paired', paired, diagnostic };
+}
+
+function statusFromError(error: unknown, paired: boolean): CliBridgeConnectionStatus {
+  if (error instanceof CliBridgeClientError) {
+    if (error.code === 'BRIDGE_INCOMPATIBLE') {
+      return { state: 'incompatible', paired, diagnostic: error.message };
+    }
+    if (error.code === 'AUTH_INVALID' || error.code === 'AUTH_REQUIRED') {
+      return notPairedStatus(paired, error.message);
+    }
+    return { state: 'offline', paired, diagnostic: error.message };
+  }
+  return {
+    state: 'offline',
+    paired,
+    diagnostic: 'Start MarkuprPlus CLI Bridge.',
+  };
+}
+
+function isCliProvider(value: unknown): boolean {
+  return typeof value === 'string'
+    && (CLI_BRIDGE_PROVIDER_IDS as readonly string[]).includes(value);
+}
+
+export function registerCliBridgeHandlers(
+  ctx: IpcContext,
+  dependencies: CliBridgeHandlerDependencies = DEFAULT_DEPENDENCIES,
+): void {
+  ipcMain.handle(IPC_CHANNELS.CLI_BRIDGE_STATUS, async (): Promise<CliBridgeConnectionStatus> => {
+    if (dependencies.distribution() !== 'mas') return notApplicableStatus();
+    const settingsManager = settingsFrom(ctx);
+    const token = await settingsManager.getApiKey(BRIDGE_SECRET_SERVICE);
+    if (!token) return notPairedStatus();
+
+    try {
+      const providers = await dependencies.createClient(settingsManager).discoverProviders(false);
+      return { state: 'connected', paired: true, providers };
+    } catch (error) {
+      return statusFromError(error, true);
+    }
+  });
+
+  ipcMain.handle(
+    IPC_CHANNELS.CLI_BRIDGE_PAIR,
+    async (_, tokenValue: unknown): Promise<CliBridgePairResult> => {
+      if (dependencies.distribution() !== 'mas') {
+        return { success: false, status: notApplicableStatus() };
+      }
+      const settingsManager = settingsFrom(ctx);
+      const previousToken = await settingsManager.getApiKey(BRIDGE_SECRET_SERVICE);
+      const candidate = typeof tokenValue === 'string' ? tokenValue.trim() : '';
+      if (!BRIDGE_TOKEN_PATTERN.test(candidate)) {
+        return {
+          success: false,
+          status: notPairedStatus(
+            Boolean(previousToken),
+            'Enter the 43-character token printed by markuprplus bridge token.',
+          ),
+        };
+      }
+
+      try {
+        const providers = await dependencies
+          .createClient(settingsManager)
+          .discoverProviders(true, candidate);
+        await settingsManager.setApiKey(BRIDGE_SECRET_SERVICE, candidate);
+        return {
+          success: true,
+          status: { state: 'connected', paired: true, providers },
+        };
+      } catch (error) {
+        return { success: false, status: statusFromError(error, Boolean(previousToken)) };
+      }
+    },
+  );
+
+  ipcMain.handle(IPC_CHANNELS.CLI_BRIDGE_FORGET, async (): Promise<CliBridgeConnectionStatus> => {
+    if (dependencies.distribution() !== 'mas') return notApplicableStatus();
+    const settingsManager = settingsFrom(ctx);
+    await settingsManager.deleteApiKey(BRIDGE_SECRET_SERVICE);
+    if (isCliProvider(settingsManager.get('analysisProvider'))) {
+      settingsManager.set('analysisProvider', 'rules');
+    }
+    return notPairedStatus();
+  });
+}

--- a/src/main/ipc/index.ts
+++ b/src/main/ipc/index.ts
@@ -11,6 +11,7 @@ export { registerSettingsHandlers } from './settingsHandlers';
 export { registerOutputHandlers } from './outputHandlers';
 export { registerWindowHandlers } from './windowHandlers';
 export { registerAnalysisProviderHandlers } from './analysisProviderHandlers';
+export { registerCliBridgeHandlers } from './cliBridgeHandlers';
 export type { IpcContext, SessionActions } from './types';
 
 // Re-export capture utilities used by the main entry point
@@ -34,6 +35,7 @@ import { registerSettingsHandlers } from './settingsHandlers';
 import { registerOutputHandlers } from './outputHandlers';
 import { registerWindowHandlers } from './windowHandlers';
 import { registerAnalysisProviderHandlers } from './analysisProviderHandlers';
+import { registerCliBridgeHandlers } from './cliBridgeHandlers';
 
 /**
  * Register all IPC handlers in a single call.
@@ -46,4 +48,5 @@ export function registerAllHandlers(ctx: IpcContext, actions: SessionActions): v
   registerOutputHandlers(ctx);
   registerWindowHandlers(ctx);
   registerAnalysisProviderHandlers(ctx);
+  registerCliBridgeHandlers(ctx);
 }

--- a/src/main/ipc/settingsHandlers.ts
+++ b/src/main/ipc/settingsHandlers.ts
@@ -206,6 +206,7 @@ export function registerSettingsHandlers(ctx: IpcContext, actions: SessionAction
 
     await settingsManager.deleteApiKey('openai').catch(() => {});
     await settingsManager.deleteApiKey('anthropic').catch(() => {});
+    await settingsManager.deleteApiKey('cli-bridge').catch(() => {});
 
     settingsManager.reset();
     crashRecovery.discardIncompleteSession();

--- a/src/main/pipeline/CaptureMomentHints.ts
+++ b/src/main/pipeline/CaptureMomentHints.ts
@@ -1,10 +1,38 @@
 import type { CaptureContextSnapshot, MarkedIssuePayload } from '../../shared/types';
 import type { KeyMoment } from './TranscriptAnalyzer';
+import type { ExtractedFrame, TranscriptSegment } from './PostProcessor';
 import { basename } from 'node:path';
 
 interface MarkedIssueFrame {
   path: string;
   markedIssueId?: string;
+}
+
+export function removeClaimedTranscriptFrames(
+  frames: ExtractedFrame[],
+  segments: TranscriptSegment[],
+  issues: MarkedIssuePayload[],
+): ExtractedFrame[] {
+  const claimedSegmentIndexes = new Set(
+    issues
+      .flatMap((issue) => issue.transcriptSegmentIds)
+      .map((id) => id.match(/^transcript-segment-(\d{4})$/)?.[1])
+      .filter((value): value is string => Boolean(value))
+      .map((value) => Number.parseInt(value, 10) - 1)
+      .filter((index) => index >= 0 && index < segments.length),
+  );
+  if (claimedSegmentIndexes.size === 0) return frames;
+
+  return frames.filter((frame) => {
+    if (frame.markedIssueId || !frame.transcriptSegment) return true;
+    const segmentIndex = segments.indexOf(frame.transcriptSegment);
+    if (segmentIndex >= 0) return !claimedSegmentIndexes.has(segmentIndex);
+    const equivalentIndex = segments.findIndex((segment) =>
+      segment.text === frame.transcriptSegment?.text
+      && segment.startTime === frame.transcriptSegment.startTime
+      && segment.endTime === frame.transcriptSegment.endTime);
+    return equivalentIndex < 0 || !claimedSegmentIndexes.has(equivalentIndex);
+  });
 }
 
 export function attachFallbackFramesToMarkedIssues(

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -52,6 +52,8 @@ import {
   type ReviewSession,
   type ReviewExportOptions,
   type ReviewExportResult,
+  type CliBridgeConnectionStatus,
+  type CliBridgePairResult,
 } from '../shared/types';
 import { ELECTRON_TEST_CHANNELS } from '../shared/electronTestHarness';
 
@@ -640,6 +642,21 @@ const markuprxApi = {
         provider,
         forceRefresh,
       );
+    },
+  },
+
+  // ===========================================================================
+  // CLI Bridge API
+  // ===========================================================================
+  cliBridge: {
+    status: (): Promise<CliBridgeConnectionStatus> => {
+      return ipcRenderer.invoke(IPC_CHANNELS.CLI_BRIDGE_STATUS);
+    },
+    pair: (token: string): Promise<CliBridgePairResult> => {
+      return ipcRenderer.invoke(IPC_CHANNELS.CLI_BRIDGE_PAIR, token);
+    },
+    forget: (): Promise<CliBridgeConnectionStatus> => {
+      return ipcRenderer.invoke(IPC_CHANNELS.CLI_BRIDGE_FORGET);
     },
   },
 

--- a/src/renderer/components/SettingsPanel.tsx
+++ b/src/renderer/components/SettingsPanel.tsx
@@ -170,10 +170,17 @@ export const SettingsPanel: React.FC<SettingsPanelProps> = ({
             whisperModelStatus={s.whisperModelStatus}
             isRepairingLocalTranscription={s.isRepairingLocalTranscription}
             localTranscriptionError={s.localTranscriptionError}
+            cliBridgeStatus={s.cliBridgeStatus}
+            cliBridgeToken={s.cliBridgeToken}
+            isUpdatingCliBridge={s.isUpdatingCliBridge}
             onSettingChange={s.handleSettingChange}
             onAnalysisModelChange={s.handleAnalysisModelChange}
             onRefreshAnalysisProviders={s.refreshAnalysisProviders}
             onRepairLocalTranscription={s.handleRepairLocalTranscription}
+            onCliBridgeTokenChange={s.setCliBridgeToken}
+            onPairCliBridge={s.handlePairCliBridge}
+            onRefreshCliBridge={s.refreshCliBridgeStatus}
+            onForgetCliBridge={s.handleForgetCliBridge}
             onOpenAiApiKeyChange={s.handleOpenAiApiKeyChange}
             onToggleOpenAiApiKeyVisibility={s.handleToggleOpenAiApiKeyVisibility}
             onTestOpenAiApiKey={s.handleTestOpenAiApiKey}
@@ -193,8 +200,10 @@ export const SettingsPanel: React.FC<SettingsPanelProps> = ({
     s.activeTab, s.settings, s.audioDevices, s.openAiApiKey, s.anthropicApiKey,
     s.analysisProviderStatuses, s.isScanningProviders, s.refreshAnalysisProviders,
     s.whisperModelStatus, s.isRepairingLocalTranscription, s.localTranscriptionError,
+    s.cliBridgeStatus, s.cliBridgeToken, s.isUpdatingCliBridge,
     s.handleSettingChange, s.handleHotkeyChange,
     s.handleAnalysisModelChange, s.handleRepairLocalTranscription,
+    s.setCliBridgeToken, s.handlePairCliBridge, s.refreshCliBridgeStatus, s.handleForgetCliBridge,
     s.handleOpenAiApiKeyChange, s.handleToggleOpenAiApiKeyVisibility, s.handleTestOpenAiApiKey,
     s.handleAnthropicApiKeyChange, s.handleToggleAnthropicApiKeyVisibility, s.handleTestAnthropicApiKey,
     s.handleClearAllData, s.handleExportSettings, s.handleImportSettings,

--- a/src/renderer/components/settings/AdvancedTab.tsx
+++ b/src/renderer/components/settings/AdvancedTab.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import type {
   AnalysisProviderStatus,
   AppSettings,
+  CliBridgeConnectionStatus,
   ModelAnalysisProvider,
   WhisperModelCheckResult,
 } from '../../../shared/types';
@@ -10,6 +11,8 @@ import { SettingsSection, ToggleSetting, ApiKeyInput, DangerButton } from '../pr
 import type { ApiKeyState } from '../primitives';
 import { styles } from './settingsStyles';
 import { AnalysisProviderSelector } from './AnalysisProviderSelector';
+import { CliBridgeSetup } from './CliBridgeSetup';
+import { currentDistribution } from '../../../shared/distribution';
 
 export const AdvancedTab: React.FC<{
   settings: AppSettings;
@@ -20,10 +23,17 @@ export const AdvancedTab: React.FC<{
   whisperModelStatus: WhisperModelCheckResult | null;
   isRepairingLocalTranscription: boolean;
   localTranscriptionError: string | null;
+  cliBridgeStatus: CliBridgeConnectionStatus | null;
+  cliBridgeToken: string;
+  isUpdatingCliBridge: boolean;
   onSettingChange: <K extends keyof AppSettings>(key: K, value: AppSettings[K]) => void;
   onAnalysisModelChange: (provider: ModelAnalysisProvider, modelId: string) => void;
   onRefreshAnalysisProviders: () => void;
   onRepairLocalTranscription: () => void;
+  onCliBridgeTokenChange: (token: string) => void;
+  onPairCliBridge: () => void;
+  onRefreshCliBridge: () => void;
+  onForgetCliBridge: () => void;
   onOpenAiApiKeyChange: (value: string) => void;
   onToggleOpenAiApiKeyVisibility: () => void;
   onTestOpenAiApiKey: () => void;
@@ -43,10 +53,17 @@ export const AdvancedTab: React.FC<{
   whisperModelStatus,
   isRepairingLocalTranscription,
   localTranscriptionError,
+  cliBridgeStatus,
+  cliBridgeToken,
+  isUpdatingCliBridge,
   onSettingChange,
   onAnalysisModelChange,
   onRefreshAnalysisProviders,
   onRepairLocalTranscription,
+  onCliBridgeTokenChange,
+  onPairCliBridge,
+  onRefreshCliBridge,
+  onForgetCliBridge,
   onOpenAiApiKeyChange,
   onToggleOpenAiApiKeyVisibility,
   onTestOpenAiApiKey,
@@ -61,6 +78,18 @@ export const AdvancedTab: React.FC<{
   const { colors } = useTheme();
   return (
   <div style={styles.tabContent}>
+    {currentDistribution() === 'mas' && (
+      <CliBridgeSetup
+        status={cliBridgeStatus}
+        token={cliBridgeToken}
+        busy={isUpdatingCliBridge}
+        onTokenChange={onCliBridgeTokenChange}
+        onPair={onPairCliBridge}
+        onRefresh={onRefreshCliBridge}
+        onForget={onForgetCliBridge}
+      />
+    )}
+
     <AnalysisProviderSelector
       provider={settings.analysisProvider}
       modelSelections={settings.analysisModelsByProvider}

--- a/src/renderer/components/settings/CliBridgeSetup.tsx
+++ b/src/renderer/components/settings/CliBridgeSetup.tsx
@@ -5,7 +5,7 @@ import { useTheme } from '../../hooks/useTheme';
 import { styles } from './settingsStyles';
 
 export const CLI_BRIDGE_SETUP_COMMANDS = [
-  'npm install -g markuprx@latest',
+  'npm install -g https://github.com/hashfunction/MarkuprPlus/releases/download/v3.1.0/markuprx-3.1.0.tgz',
   'markuprx bridge install',
   'markuprx bridge token',
 ] as const;

--- a/src/renderer/components/settings/CliBridgeSetup.tsx
+++ b/src/renderer/components/settings/CliBridgeSetup.tsx
@@ -1,0 +1,181 @@
+import React, { useState } from 'react';
+import type { CliBridgeConnectionStatus } from '../../../shared/types';
+import { SettingsSection } from '../primitives';
+import { useTheme } from '../../hooks/useTheme';
+import { styles } from './settingsStyles';
+
+export const CLI_BRIDGE_SETUP_COMMANDS = [
+  'npm install -g markuprx@latest',
+  'markuprx bridge install',
+  'markuprx bridge token',
+] as const;
+
+export interface CliBridgeStatusPresentation {
+  label: string;
+  detail: string;
+  tone: 'neutral' | 'success' | 'warning';
+}
+
+export function getCliBridgeStatusPresentation(
+  status: CliBridgeConnectionStatus | null,
+): CliBridgeStatusPresentation {
+  if (!status) {
+    return { label: 'Checking bridge…', detail: 'Checking this Mac.', tone: 'neutral' };
+  }
+  switch (status.state) {
+    case 'connected': {
+      const providers = status.providers ?? [];
+      const ready = providers.filter(({ ready: providerReady }) => providerReady).length;
+      return {
+        label: 'Connected',
+        detail: `${ready} of ${providers.length} CLI providers ready`,
+        tone: 'success',
+      };
+    }
+    case 'offline':
+      return {
+        label: 'Bridge offline',
+        detail: status.diagnostic || 'Run markuprx bridge start.',
+        tone: 'warning',
+      };
+    case 'incompatible':
+      return {
+        label: 'Update required',
+        detail: status.diagnostic || 'Update the companion CLI Bridge.',
+        tone: 'warning',
+      };
+    case 'not-paired':
+      return {
+        label: status.paired ? 'Pairing rejected' : 'Not paired',
+        detail: status.diagnostic || 'Paste the bridge token below.',
+        tone: 'warning',
+      };
+    case 'not-applicable':
+      return {
+        label: 'Built in',
+        detail: status.diagnostic || 'CLI providers run directly in this build.',
+        tone: 'success',
+      };
+  }
+}
+
+export const CliBridgeSetup: React.FC<{
+  status: CliBridgeConnectionStatus | null;
+  token: string;
+  busy: boolean;
+  onTokenChange: (token: string) => void;
+  onPair: () => void;
+  onRefresh: () => void;
+  onForget: () => void;
+}> = ({ status, token, busy, onTokenChange, onPair, onRefresh, onForget }) => {
+  const { colors } = useTheme();
+  const [copiedCommand, setCopiedCommand] = useState<string | null>(null);
+  if (status?.state === 'not-applicable') return null;
+  const presentation = getCliBridgeStatusPresentation(status);
+  const toneColor = presentation.tone === 'success'
+    ? colors.status.success
+    : presentation.tone === 'warning'
+      ? colors.status.warning
+      : colors.text.secondary;
+
+  const copyCommand = async (command: string) => {
+    await window.markuprx.copyToClipboard(command);
+    setCopiedCommand(command);
+    window.setTimeout(() => setCopiedCommand((current) => current === command ? null : current), 1_500);
+  };
+
+  return (
+    <SettingsSection
+      title="CLI Integrations"
+      description="Connect the App Store app to AI CLIs already installed and signed in on this Mac."
+    >
+      <div style={{ display: 'grid', gap: 8 }}>
+        {CLI_BRIDGE_SETUP_COMMANDS.map((command, index) => (
+          <div
+            key={command}
+            style={{
+              display: 'grid',
+              gridTemplateColumns: '20px minmax(0, 1fr) auto',
+              alignItems: 'center',
+              gap: 8,
+            }}
+          >
+            <span aria-hidden="true" style={{ color: colors.text.tertiary, fontSize: 11 }}>
+              {index + 1}
+            </span>
+            <code style={{
+              minWidth: 0,
+              padding: '7px 9px',
+              borderRadius: 7,
+              background: colors.bg.tertiary,
+              color: colors.text.primary,
+              fontSize: 11,
+              overflowWrap: 'anywhere',
+              userSelect: 'text',
+            }}>
+              {command}
+            </code>
+            <button
+              type="button"
+              style={styles.secondaryButton}
+              aria-label={`Copy ${command}`}
+              onClick={() => void copyCommand(command)}
+            >
+              {copiedCommand === command ? 'Copied' : 'Copy'}
+            </button>
+          </div>
+        ))}
+      </div>
+
+      <div aria-live="polite" style={{ display: 'grid', gap: 3 }}>
+        <span style={{ ...styles.settingLabel, color: toneColor }}>{presentation.label}</span>
+        <span style={styles.settingDescription}>{presentation.detail}</span>
+      </div>
+
+      <form
+        onSubmit={(event) => {
+          event.preventDefault();
+          onPair();
+        }}
+        style={{ display: 'grid', gap: 8 }}
+      >
+        <label htmlFor="cli-bridge-token" style={styles.settingLabel}>Pairing token</label>
+        <input
+          id="cli-bridge-token"
+          type="password"
+          value={token}
+          autoComplete="off"
+          spellCheck={false}
+          placeholder="Paste the token from step 3"
+          aria-describedby="cli-bridge-token-help"
+          onChange={(event) => onTokenChange(event.target.value)}
+          style={{ ...styles.apiKeyInput, width: '100%', boxSizing: 'border-box' }}
+        />
+        <span id="cli-bridge-token-help" style={styles.settingDescription}>
+          The token is verified first, then stored in your macOS Keychain. It is never shown again.
+        </span>
+        <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap' }}>
+          <button
+            type="submit"
+            style={styles.secondaryButton}
+            disabled={busy || token.trim().length === 0}
+          >
+            {busy ? 'Connecting…' : status?.paired ? 'Replace pairing' : 'Pair bridge'}
+          </button>
+          <button type="button" style={styles.secondaryButton} disabled={busy} onClick={onRefresh}>
+            Refresh status
+          </button>
+          {status?.paired && (
+            <button type="button" style={styles.secondaryButton} disabled={busy} onClick={onForget}>
+              Disconnect
+            </button>
+          )}
+        </div>
+      </form>
+
+      <span style={styles.settingDescription}>
+        The companion handles only structured report requests from this app on localhost. The App Store app does not execute shell commands.
+      </span>
+    </SettingsSection>
+  );
+};

--- a/src/renderer/components/settings/analysisProviderOptions.ts
+++ b/src/renderer/components/settings/analysisProviderOptions.ts
@@ -104,8 +104,13 @@ const ALL_PROVIDER_OPTIONS: AnalysisProviderOption[] = [
 export function providerOptionsForDistribution(
   distribution: DistributionKind,
 ): AnalysisProviderOption[] {
-  return ALL_PROVIDER_OPTIONS.filter((option) =>
-    distribution === 'direct' || option.connectionBadge !== 'CLI');
+  if (distribution === 'direct') return ALL_PROVIDER_OPTIONS;
+  return ALL_PROVIDER_OPTIONS.map((option) => option.connectionBadge === 'CLI'
+    ? {
+        ...option,
+        description: `${option.description} Runs through the companion CLI Bridge.`,
+      }
+    : option);
 }
 
 export const PROVIDER_OPTIONS = providerOptionsForDistribution(currentDistribution());

--- a/src/renderer/components/settings/index.ts
+++ b/src/renderer/components/settings/index.ts
@@ -3,6 +3,7 @@ export { RecordingTab } from './RecordingTab';
 export { AppearanceTab } from './AppearanceTab';
 export { HotkeysTab } from './HotkeysTab';
 export { AdvancedTab } from './AdvancedTab';
+export { CliBridgeSetup } from './CliBridgeSetup';
 export { TABS } from './tabConfig';
 export type { SettingsTab } from './tabConfig';
 export { styles as settingsStyles } from './settingsStyles';

--- a/src/renderer/components/settings/useSettingsPanel.ts
+++ b/src/renderer/components/settings/useSettingsPanel.ts
@@ -10,6 +10,7 @@ import type {
   AnalysisProviderStatus,
   AppSettings,
   AudioDevice,
+  CliBridgeConnectionStatus,
   HotkeyConfig,
   ModelAnalysisProvider,
   WhisperModelCheckResult,
@@ -18,6 +19,8 @@ import { DEFAULT_SETTINGS, DEFAULT_HOTKEY_CONFIG } from '../../../shared/types';
 import type { ApiKeyState } from '../primitives';
 import type { SettingsTab } from './tabConfig';
 import { getAnalysisProviderViewState } from './analysisProviderViewState';
+import { currentDistribution } from '../../../shared/distribution';
+import { CLI_BRIDGE_PROVIDER_IDS } from '../../../shared/cliBridgeProtocol';
 
 // ============================================================================
 // Constants
@@ -26,6 +29,7 @@ import { getAnalysisProviderViewState } from './analysisProviderViewState';
 const MASKED_API_KEY_PLACEHOLDER = '********';
 const API_TEST_TIMEOUT_MS = 15000;
 const API_SAVE_TIMEOUT_MS = 12000;
+const IS_MAS_DISTRIBUTION = currentDistribution() === 'mas';
 
 export type SettingsSaveStatus = 'idle' | 'saving' | 'saved' | 'error';
 
@@ -72,6 +76,9 @@ export function useSettingsPanel(isOpen: boolean, onClose: () => void, initialTa
   const [whisperModelStatus, setWhisperModelStatus] = useState<WhisperModelCheckResult | null>(null);
   const [isRepairingLocalTranscription, setIsRepairingLocalTranscription] = useState(false);
   const [localTranscriptionError, setLocalTranscriptionError] = useState<string | null>(null);
+  const [cliBridgeStatus, setCliBridgeStatus] = useState<CliBridgeConnectionStatus | null>(null);
+  const [cliBridgeToken, setCliBridgeToken] = useState('');
+  const [isUpdatingCliBridge, setIsUpdatingCliBridge] = useState(false);
   const getApiKeyPresence = useCallback(async (): Promise<{ hasOpenAiKey: boolean; hasAnthropicKey: boolean }> => {
     try {
       const [hasOpenAiKey, hasAnthropicKey] = await Promise.all([
@@ -99,6 +106,28 @@ export function useSettingsPanel(isOpen: boolean, onClose: () => void, initialTa
     }
   }, []);
 
+  const refreshCliBridgeStatus = useCallback(async (): Promise<CliBridgeConnectionStatus | null> => {
+    if (!IS_MAS_DISTRIBUTION) return null;
+    setIsUpdatingCliBridge(true);
+    try {
+      const status = await window.markuprx.cliBridge.status();
+      setCliBridgeStatus(status);
+      if (status.state === 'connected') await refreshAnalysisProviders(true);
+      return status;
+    } catch (error) {
+      console.error('Failed to check CLI Bridge:', error);
+      const status: CliBridgeConnectionStatus = {
+        state: 'offline',
+        paired: false,
+        diagnostic: 'Unable to check the companion CLI Bridge.',
+      };
+      setCliBridgeStatus(status);
+      return status;
+    } finally {
+      setIsUpdatingCliBridge(false);
+    }
+  }, [refreshAnalysisProviders]);
+
   // ---------------------------------------------------------------------------
   // Load settings on mount
   // ---------------------------------------------------------------------------
@@ -112,14 +141,22 @@ export function useSettingsPanel(isOpen: boolean, onClose: () => void, initialTa
         const loadedSettings = { ...DEFAULT_SETTINGS, ...allSettings };
         setSettings(loadedSettings);
 
-        const [devices, providerStatuses, { hasOpenAiKey, hasAnthropicKey }, localModelStatus] = await Promise.all([
+        const [devices, providerStatuses, { hasOpenAiKey, hasAnthropicKey }, localModelStatus, bridgeStatus] = await Promise.all([
           window.markuprx.audio.getDevices(),
           refreshAnalysisProviders(false),
           getApiKeyPresence(),
           window.markuprx.whisper.checkModel().catch(() => null),
+          IS_MAS_DISTRIBUTION
+            ? window.markuprx.cliBridge.status().catch((): CliBridgeConnectionStatus => ({
+                state: 'offline',
+                paired: false,
+                diagnostic: 'Unable to check the companion CLI Bridge.',
+              }))
+            : Promise.resolve(null),
         ]);
         setAudioDevices(devices);
         setWhisperModelStatus(localModelStatus);
+        setCliBridgeStatus(bridgeStatus);
         if (hasOpenAiKey) {
           setOpenAiApiKey((prev) => ({ ...prev, value: MASKED_API_KEY_PLACEHOLDER, valid: true }));
         }
@@ -193,6 +230,49 @@ export function useSettingsPanel(isOpen: boolean, onClose: () => void, initialTa
     else delete next[provider];
     await handleSettingChange('analysisModelsByProvider', next);
   }, [settings.analysisModelsByProvider, handleSettingChange]);
+
+  const handlePairCliBridge = useCallback(async () => {
+    if (!IS_MAS_DISTRIBUTION) return;
+    setIsUpdatingCliBridge(true);
+    try {
+      const result = await window.markuprx.cliBridge.pair(cliBridgeToken);
+      setCliBridgeStatus(result.status);
+      if (result.success) {
+        setCliBridgeToken('');
+        await refreshAnalysisProviders(true);
+      }
+    } catch (error) {
+      console.error('Failed to pair CLI Bridge:', error);
+      setCliBridgeStatus({
+        state: 'offline',
+        paired: cliBridgeStatus?.paired ?? false,
+        diagnostic: 'Unable to pair with the companion CLI Bridge.',
+      });
+    } finally {
+      setIsUpdatingCliBridge(false);
+    }
+  }, [cliBridgeStatus?.paired, cliBridgeToken, refreshAnalysisProviders]);
+
+  const handleForgetCliBridge = useCallback(async () => {
+    if (!IS_MAS_DISTRIBUTION) return;
+    setIsUpdatingCliBridge(true);
+    try {
+      const status = await window.markuprx.cliBridge.forget();
+      setCliBridgeStatus(status);
+      setCliBridgeToken('');
+      if ((CLI_BRIDGE_PROVIDER_IDS as readonly string[]).includes(settings.analysisProvider)) {
+        setSettings((previous) => ({ ...previous, analysisProvider: 'rules' }));
+      }
+      await refreshAnalysisProviders(true);
+      window.dispatchEvent(new CustomEvent('markuprx:settings-updated', {
+        detail: { type: 'analysis-provider', provider: 'rules' },
+      }));
+    } catch (error) {
+      console.error('Failed to forget CLI Bridge:', error);
+    } finally {
+      setIsUpdatingCliBridge(false);
+    }
+  }, [refreshAnalysisProviders, settings.analysisProvider]);
 
   const handleRepairLocalTranscription = useCallback(async () => {
     setIsRepairingLocalTranscription(true);
@@ -534,6 +614,12 @@ export function useSettingsPanel(isOpen: boolean, onClose: () => void, initialTa
       setOpenAiApiKey({ value: '', visible: false, testing: false, valid: null, error: null });
       setAnthropicApiKey({ value: '', visible: false, testing: false, valid: null, error: null });
       setAnalysisProviderStatuses([]);
+      setCliBridgeToken('');
+      setCliBridgeStatus(IS_MAS_DISTRIBUTION ? {
+        state: 'not-paired',
+        paired: false,
+        diagnostic: 'Pair MarkuprPlus CLI Bridge.',
+      } : null);
       window.dispatchEvent(new CustomEvent('markuprx:settings-updated', { detail: { type: 'reset' } }));
     } catch (error) {
       console.error('Failed to clear data:', error);
@@ -605,6 +691,10 @@ export function useSettingsPanel(isOpen: boolean, onClose: () => void, initialTa
     isRepairingLocalTranscription,
     localTranscriptionError,
     analysisProviderViewState,
+    cliBridgeStatus,
+    cliBridgeToken,
+    setCliBridgeToken,
+    isUpdatingCliBridge,
 
     // Setting handlers
     handleSettingChange,
@@ -612,6 +702,9 @@ export function useSettingsPanel(isOpen: boolean, onClose: () => void, initialTa
     handleRepairLocalTranscription,
     handleHotkeyChange,
     refreshAnalysisProviders,
+    refreshCliBridgeStatus,
+    handlePairCliBridge,
+    handleForgetCliBridge,
 
     // API key handlers
     handleOpenAiApiKeyChange,

--- a/src/shared/cliBridgeProtocol.ts
+++ b/src/shared/cliBridgeProtocol.ts
@@ -1,0 +1,304 @@
+import { z } from 'zod';
+import type { AnalysisModelOption, AnalysisProviderStatus } from './types';
+import type { AIAnalysisResult } from '../main/ai/types';
+
+export const CLI_BRIDGE_PROTOCOL_VERSION = 1 as const;
+export const CLI_BRIDGE_DEFAULT_HOST = '127.0.0.1' as const;
+export const CLI_BRIDGE_DEFAULT_PORT = 49_647 as const;
+export const CLI_BRIDGE_MAX_BODY_BYTES = 32 * 1024 * 1024;
+export const CLI_BRIDGE_MAX_SCREENSHOTS = 20;
+export const CLI_BRIDGE_MAX_SCREENSHOT_BYTES = 8 * 1024 * 1024;
+export const CLI_BRIDGE_MAX_SESSION_ITEMS = 2_000;
+
+export const CLI_BRIDGE_PROVIDER_IDS = [
+  'codex-cli',
+  'claude-cli',
+  'opencode-cli',
+  'cursor-cli',
+  'qwen-cli',
+  'goose-cli',
+  'amp-cli',
+  'kiro-cli',
+  'aider-cli',
+] as const;
+
+export type CliBridgeProvider = typeof CLI_BRIDGE_PROVIDER_IDS[number];
+
+export type CliBridgeErrorCode =
+  | 'AUTH_REQUIRED'
+  | 'AUTH_INVALID'
+  | 'METHOD_NOT_ALLOWED'
+  | 'NOT_FOUND'
+  | 'PAYLOAD_TOO_LARGE'
+  | 'INVALID_REQUEST'
+  | 'PROVIDER_UNSUPPORTED'
+  | 'BRIDGE_BUSY'
+  | 'PROVIDER_UNAVAILABLE'
+  | 'ANALYSIS_TIMEOUT'
+  | 'ANALYSIS_FAILED'
+  | 'INTERNAL_ERROR'
+  | 'BRIDGE_PROTOCOL_ERROR';
+
+export interface BridgeErrorEnvelope {
+  error: {
+    code: CliBridgeErrorCode;
+    message: string;
+  };
+}
+
+export interface BridgeHealthResponse {
+  bridgeVersion: string;
+  protocolVersion: number;
+  pairingConfigured: boolean;
+}
+
+export interface BridgeProvidersResponse {
+  protocolVersion: number;
+  providers: AnalysisProviderStatus[];
+}
+
+export interface BridgeModelsResponse {
+  protocolVersion: number;
+  models: AnalysisModelOption[];
+}
+
+export interface BridgeAnalysisResponse {
+  protocolVersion: number;
+  analysis: AIAnalysisResult;
+}
+
+const boundedString = (max = 4_096) => z.string().max(max);
+const finiteNumber = z.number();
+const nonnegativeInteger = z.number().int().nonnegative();
+const sessionStateSchema = z.enum([
+  'idle', 'starting', 'recording', 'stopping', 'processing', 'complete', 'error',
+]);
+const providerSchema = z.enum(CLI_BRIDGE_PROVIDER_IDS);
+
+const boundsSchema = z.object({
+  x: finiteNumber,
+  y: finiteNumber,
+  width: finiteNumber,
+  height: finiteNumber,
+}).strict();
+
+const captureTargetSchema = z.discriminatedUnion('kind', [
+  z.object({
+    kind: z.literal('window'),
+    sourceId: boundedString(),
+    sourceName: boundedString(),
+    nativeWindowId: boundedString(),
+    appName: boundedString(),
+    bounds: boundsSchema,
+    geometryAvailable: z.boolean().optional(),
+  }).strict(),
+  z.object({
+    kind: z.literal('region'),
+    sourceId: boundedString(),
+    sourceName: boundedString(),
+    displayId: boundedString(),
+    displayBounds: boundsSchema,
+    scaleFactor: finiteNumber,
+    region: boundsSchema,
+  }).strict(),
+  z.object({
+    kind: z.literal('screen'),
+    sourceId: boundedString(),
+    sourceName: boundedString(),
+    displayId: boundedString(),
+    displayBounds: boundsSchema,
+    scaleFactor: finiteNumber,
+  }).strict(),
+]);
+
+const focusedElementSchema = z.object({
+  source: z.enum(['renderer-dom', 'os-accessibility', 'window-title', 'unknown']),
+  role: boundedString().optional(),
+  tagName: boundedString().optional(),
+  id: boundedString().optional(),
+  name: boundedString().optional(),
+  label: boundedString().optional(),
+  placeholder: boundedString().optional(),
+  textPreview: boundedString().optional(),
+  appName: boundedString().optional(),
+  windowTitle: boundedString().optional(),
+}).strict();
+
+const captureContextSchema = z.object({
+  recordedAt: finiteNumber,
+  trigger: z.enum(['pause', 'manual', 'voice-command', 'annotation']),
+  cursor: z.object({
+    x: finiteNumber,
+    y: finiteNumber,
+    displayId: boundedString().optional(),
+    displayLabel: boundedString().optional(),
+    relativeX: finiteNumber.optional(),
+    relativeY: finiteNumber.optional(),
+  }).strict().optional(),
+  activeWindow: z.object({
+    sourceId: boundedString().optional(),
+    sourceName: boundedString().optional(),
+    sourceType: z.enum(['screen', 'window', 'region']).optional(),
+    appName: boundedString().optional(),
+    title: boundedString().optional(),
+    pid: nonnegativeInteger.optional(),
+  }).strict().optional(),
+  focusedElement: focusedElementSchema.optional(),
+  annotation: z.object({
+    strokeId: boundedString(),
+    tool: z.enum(['freehand', 'circle', 'highlight']),
+    color: z.enum(['#ff3b30', '#ffcc00', '#34c759', '#0a84ff']),
+  }).strict().optional(),
+}).strict();
+
+const markedIssueSchema = z.object({
+  id: boundedString(),
+  ordinal: nonnegativeInteger,
+  startedAt: finiteNumber,
+  markedAt: finiteNumber,
+  completedAt: finiteNumber,
+  strokeIds: z.array(boundedString()).max(CLI_BRIDGE_MAX_SESSION_ITEMS),
+  tools: z.array(z.enum(['freehand', 'circle', 'highlight'])).max(CLI_BRIDGE_MAX_SESSION_ITEMS),
+  colors: z.array(z.enum(['#ff3b30', '#ffcc00', '#34c759', '#0a84ff']))
+    .max(CLI_BRIDGE_MAX_SESSION_ITEMS),
+  fallbackVideoTimestamp: finiteNumber,
+  captureContext: captureContextSchema.optional(),
+  comment: boundedString(1024 * 1024).optional(),
+  transcriptionStatus: z.enum(['pending', 'available', 'unavailable']),
+  transcriptionWarning: boundedString().optional(),
+  snapshotRevision: nonnegativeInteger,
+  transcriptSegmentIds: z.array(boundedString()).max(CLI_BRIDGE_MAX_SESSION_ITEMS),
+  evidenceWarning: boundedString().optional(),
+}).strict();
+
+const metadataSchema = z.object({
+  sourceId: boundedString(),
+  sourceName: boundedString().optional(),
+  sourceType: z.enum(['screen', 'window', 'region']).optional(),
+  captureTarget: captureTargetSchema.optional(),
+  windowTitle: boundedString().optional(),
+  appName: boundedString().optional(),
+  recordingMimeType: boundedString(256).optional(),
+  recordingBytes: nonnegativeInteger.optional(),
+  audioBytes: nonnegativeInteger.optional(),
+  audioDurationMs: finiteNumber.nonnegative().optional(),
+  videoStartTime: finiteNumber.optional(),
+  captureContexts: z.array(captureContextSchema).max(CLI_BRIDGE_MAX_SESSION_ITEMS).optional(),
+  markedIssues: z.array(markedIssueSchema).max(CLI_BRIDGE_MAX_SESSION_ITEMS).optional(),
+  transcriptionFailure: z.object({
+    code: z.enum([
+      'audio-unavailable', 'not-configured', 'openai-failed', 'whisper-failed', 'no-speech',
+    ]),
+    message: boundedString(),
+  }).strict().optional(),
+}).strict();
+
+const feedbackItemSchema = z.object({
+  id: boundedString(),
+  timestamp: finiteNumber,
+  text: boundedString(1024 * 1024),
+  confidence: finiteNumber,
+}).strict();
+
+const transcriptEventSchema = z.object({
+  text: boundedString(1024 * 1024),
+  isFinal: z.boolean(),
+  confidence: finiteNumber,
+  timestamp: finiteNumber,
+  tier: z.enum(['whisper', 'timer-only']),
+}).strict();
+
+function decodedBase64ByteLength(value: string): number | null {
+  if (value.length === 0 || value.length % 4 !== 0) return null;
+  const padding = value.endsWith('==') ? 2 : value.endsWith('=') ? 1 : 0;
+  for (let index = 0; index < value.length - padding; index += 1) {
+    const code = value.charCodeAt(index);
+    const valid =
+      (code >= 0x41 && code <= 0x5a)
+      || (code >= 0x61 && code <= 0x7a)
+      || (code >= 0x30 && code <= 0x39)
+      || code === 0x2b
+      || code === 0x2f;
+    if (!valid) return null;
+  }
+  for (let index = value.length - padding; index < value.length; index += 1) {
+    if (value[index] !== '=') return null;
+  }
+  return (value.length / 4) * 3 - padding;
+}
+
+const screenshotSchema = z.object({
+  id: boundedString(),
+  timestamp: finiteNumber,
+  width: z.number().int().positive().max(100_000),
+  height: z.number().int().positive().max(100_000),
+  mimeType: z.enum(['image/png', 'image/jpeg']),
+  dataBase64: z.string().superRefine((value, context) => {
+    const decodedBytes = decodedBase64ByteLength(value);
+    if (decodedBytes === null || decodedBytes > CLI_BRIDGE_MAX_SCREENSHOT_BYTES) {
+      context.addIssue({
+        code: 'custom',
+        message: 'Screenshot data must be valid base64 within the decoded byte limit.',
+      });
+    }
+  }),
+}).strict();
+
+export const bridgeSessionSchema = z.object({
+  id: boundedString(),
+  startTime: finiteNumber,
+  endTime: finiteNumber.optional(),
+  state: sessionStateSchema,
+  sourceId: boundedString(),
+  feedbackItems: z.array(feedbackItemSchema).max(CLI_BRIDGE_MAX_SESSION_ITEMS),
+  transcriptBuffer: z.array(transcriptEventSchema).max(CLI_BRIDGE_MAX_SESSION_ITEMS),
+  screenshots: z.array(screenshotSchema).max(CLI_BRIDGE_MAX_SCREENSHOTS),
+  metadata: metadataSchema,
+}).strict();
+
+export type BridgeSessionPayload = z.infer<typeof bridgeSessionSchema>;
+
+const bridgeAnalyzeRequestSchema = z.object({
+  protocolVersion: z.literal(CLI_BRIDGE_PROTOCOL_VERSION),
+  provider: providerSchema,
+  modelId: z.string()
+    .min(1)
+    .max(200)
+    .refine((value) => !Array.from(value).some((character) => {
+      const code = character.charCodeAt(0);
+      return code <= 0x1f || code === 0x7f;
+    }), 'Model ID cannot contain control characters.')
+    .optional(),
+  session: bridgeSessionSchema,
+}).strict();
+
+export type BridgeAnalyzeRequest = z.infer<typeof bridgeAnalyzeRequestSchema>;
+
+export function isCliBridgeProvider(value: unknown): value is CliBridgeProvider {
+  return typeof value === 'string'
+    && (CLI_BRIDGE_PROVIDER_IDS as readonly string[]).includes(value);
+}
+
+export function parseBridgeSessionPayload(value: unknown): BridgeSessionPayload {
+  const result = bridgeSessionSchema.safeParse(value);
+  if (!result.success) {
+    throw new Error('Invalid bridge session payload.');
+  }
+  return result.data;
+}
+
+export function parseBridgeAnalyzeRequest(value: unknown): BridgeAnalyzeRequest {
+  if (
+    value
+    && typeof value === 'object'
+    && 'provider' in value
+    && !isCliBridgeProvider((value as { provider?: unknown }).provider)
+  ) {
+    throw new Error('Unsupported provider.');
+  }
+  const result = bridgeAnalyzeRequestSchema.safeParse(value);
+  if (!result.success) {
+    throw new Error('Invalid bridge request.');
+  }
+  return result.data;
+}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -309,6 +309,25 @@ export interface ApiKeyValidationResult {
   status?: number;
 }
 
+export type CliBridgeConnectionState =
+  | 'not-applicable'
+  | 'not-paired'
+  | 'offline'
+  | 'incompatible'
+  | 'connected';
+
+export interface CliBridgeConnectionStatus {
+  state: CliBridgeConnectionState;
+  paired: boolean;
+  diagnostic?: string;
+  providers?: AnalysisProviderStatus[];
+}
+
+export interface CliBridgePairResult {
+  success: boolean;
+  status: CliBridgeConnectionStatus;
+}
+
 /**
  * Default settings
  */
@@ -475,6 +494,13 @@ export const IPC_CHANNELS = {
   ANALYSIS_PROVIDERS_DISCOVER: 'markuprx:analysis-providers:discover',
   ANALYSIS_PROVIDER_TEST: 'markuprx:analysis-provider:test',
   ANALYSIS_PROVIDER_MODELS: 'markuprx:analysis-provider:models',
+
+  // ---------------------------------------------------------------------------
+  // CLI Bridge Channels (Renderer -> Main)
+  // ---------------------------------------------------------------------------
+  CLI_BRIDGE_STATUS: 'markuprx:cli-bridge:status',
+  CLI_BRIDGE_PAIR: 'markuprx:cli-bridge:pair',
+  CLI_BRIDGE_FORGET: 'markuprx:cli-bridge:forget',
 
   // ---------------------------------------------------------------------------
   // Permissions Channels (Renderer -> Main)

--- a/tests/integration/cliBridgeHttp.test.ts
+++ b/tests/integration/cliBridgeHttp.test.ts
@@ -1,0 +1,184 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { AIAnalysisResult } from '../../src/main/ai/types';
+import { createAnalysisProviderRegistry } from '../../src/main/ai/providers/AnalysisProviderRegistry';
+import type { AnalysisProviderAdapter } from '../../src/main/ai/providers/types';
+import { startCliBridgeServer } from '../../src/bridge/CliBridgeServer';
+
+const token = 'b'.repeat(43);
+const session = {
+  id: 'session-1',
+  startTime: 1_700_000_000_000,
+  state: 'complete',
+  sourceId: 'screen:0:0',
+  feedbackItems: [],
+  transcriptBuffer: [{
+    text: 'The button is clipped.',
+    isFinal: true,
+    confidence: 0.9,
+    timestamp: 1_700_000_001,
+    tier: 'whisper',
+  }],
+  screenshots: [],
+  metadata: { sourceId: 'screen:0:0', sourceName: 'Browser', sourceType: 'screen' },
+} as const;
+
+const result: AIAnalysisResult = {
+  summary: 'The primary action is clipped.',
+  items: [],
+  themes: ['Layout'],
+  positiveNotes: [],
+  metadata: { totalItems: 0, criticalCount: 0, highCount: 0 },
+};
+
+function adapter(analyze: AnalysisProviderAdapter['analyze']): AnalysisProviderAdapter {
+  return {
+    id: 'codex-cli',
+    name: 'Codex CLI',
+    connection: 'cli',
+    discover: vi.fn(async () => ({
+      id: 'codex-cli',
+      name: 'Codex CLI',
+      connection: 'cli' as const,
+      installed: true,
+      authenticated: true,
+      ready: true,
+      models: [],
+    })),
+    analyze,
+  };
+}
+
+function analyzeBody() {
+  return JSON.stringify({
+    protocolVersion: 1,
+    provider: 'codex-cli',
+    session,
+  });
+}
+
+describe('CLI bridge real HTTP behavior', () => {
+  it('returns an analysis result through a real loopback request', async () => {
+    const handle = await startCliBridgeServer({
+      token,
+      bridgeVersion: '3.1.0',
+      registry: createAnalysisProviderRegistry([adapter(async () => result)]),
+      port: 0,
+    });
+    try {
+      const response = await fetch(`${handle.origin}/v1/analyze`, {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${token}`,
+          'Content-Type': 'application/json',
+        },
+        body: analyzeBody(),
+      });
+      expect(response.status).toBe(200);
+      expect(await response.json()).toEqual({ protocolVersion: 1, analysis: result });
+    } finally {
+      await handle.close();
+    }
+  });
+
+  it('rejects a second analysis while one is active', async () => {
+    let release!: (value: AIAnalysisResult) => void;
+    let started!: () => void;
+    const didStart = new Promise<void>((resolve) => { started = resolve; });
+    const pending = new Promise<AIAnalysisResult>((resolve) => { release = resolve; });
+    const handle = await startCliBridgeServer({
+      token,
+      bridgeVersion: '3.1.0',
+      registry: createAnalysisProviderRegistry([adapter(async () => {
+        started();
+        return pending;
+      })]),
+      port: 0,
+    });
+    const options = {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      },
+      body: analyzeBody(),
+    };
+    try {
+      const first = fetch(`${handle.origin}/v1/analyze`, options);
+      await didStart;
+      const second = await fetch(`${handle.origin}/v1/analyze`, options);
+      expect(second.status).toBe(429);
+      expect(await second.json()).toMatchObject({ error: { code: 'BRIDGE_BUSY' } });
+      release(result);
+      expect((await first).status).toBe(200);
+    } finally {
+      release(result);
+      await handle.close();
+    }
+  });
+
+  it('times out stalled analysis and sanitizes provider failures', async () => {
+    const timeoutHandle = await startCliBridgeServer({
+      token,
+      bridgeVersion: '3.1.0',
+      registry: createAnalysisProviderRegistry([adapter(async () => new Promise(() => {}))]),
+      analysisTimeoutMs: 20,
+      port: 0,
+    });
+    try {
+      const response = await fetch(`${timeoutHandle.origin}/v1/analyze`, {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+        body: analyzeBody(),
+      });
+      expect(response.status).toBe(504);
+      expect(await response.json()).toMatchObject({ error: { code: 'ANALYSIS_TIMEOUT' } });
+    } finally {
+      await timeoutHandle.close();
+    }
+
+    const secret = 'sk-proj-abcdefghijklmnopqrstuvwxyz123456';
+    const failureHandle = await startCliBridgeServer({
+      token,
+      bridgeVersion: '3.1.0',
+      registry: createAnalysisProviderRegistry([adapter(async () => {
+        throw new Error(`Provider rejected api_key=${secret}`);
+      })]),
+      port: 0,
+    });
+    try {
+      const response = await fetch(`${failureHandle.origin}/v1/analyze`, {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+        body: analyzeBody(),
+      });
+      const text = await response.text();
+      expect(response.status).toBe(502);
+      expect(text).toContain('[redacted]');
+      expect(text).not.toContain(secret);
+      expect(text).not.toContain('at ');
+    } finally {
+      await failureHandle.close();
+    }
+  });
+
+  it('stops buffering oversized bodies', async () => {
+    const handle = await startCliBridgeServer({
+      token,
+      bridgeVersion: '3.1.0',
+      registry: createAnalysisProviderRegistry([adapter(async () => result)]),
+      maxBodyBytes: 64,
+      port: 0,
+    });
+    try {
+      const response = await fetch(`${handle.origin}/v1/analyze`, {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+        body: JSON.stringify({ value: 'x'.repeat(128) }),
+      });
+      expect(response.status).toBe(413);
+      expect(await response.json()).toMatchObject({ error: { code: 'PAYLOAD_TOO_LARGE' } });
+    } finally {
+      await handle.close();
+    }
+  });
+});

--- a/tests/unit/ai/analysisProviderRegistry.test.ts
+++ b/tests/unit/ai/analysisProviderRegistry.test.ts
@@ -9,6 +9,7 @@ import {
   createCliAnalysisProviderRegistry,
   createDefaultAnalysisProviderRegistry,
 } from '../../../src/main/ai/providers/AnalysisProviderRegistry';
+import { BridgeCliProvider } from '../../../src/main/ai/bridge/BridgeCliProvider';
 
 const sessionFixture = {
   id: 'registry-session',
@@ -123,20 +124,37 @@ describe('AnalysisProviderRegistry', () => {
     ]);
   });
 
-  it('omits external CLI adapters when the distribution forbids child tools', () => {
+  it('uses bridge adapters for every CLI in the Store distribution', () => {
     const settingsManager = {
       hasApiKey: vi.fn(async () => false),
       getApiKey: vi.fn(async () => null),
     } as never;
-    const registry = createDefaultAnalysisProviderRegistry(settingsManager, false);
+    const bridgeClient = {
+      discoverProviders: vi.fn(async () => []),
+    } as never;
+    const registry = createDefaultAnalysisProviderRegistry(settingsManager, {
+      distribution: 'mas',
+      bridgeClient,
+    });
 
-    expect(() => registry.get('codex-cli')).toThrow('Unsupported analysis provider: codex-cli');
-    expect(() => registry.get('claude-cli')).toThrow('Unsupported analysis provider: claude-cli');
-    expect(() => registry.get('opencode-cli')).toThrow(
-      'Unsupported analysis provider: opencode-cli',
-    );
+    expect(registry.get('codex-cli')).toBeInstanceOf(BridgeCliProvider);
+    expect(registry.get('claude-cli')).toBeInstanceOf(BridgeCliProvider);
+    expect(registry.get('opencode-cli')).toBeInstanceOf(BridgeCliProvider);
     expect(registry.get('ollama')).toMatchObject({ id: 'ollama' });
     expect(registry.get('lmstudio')).toMatchObject({ id: 'lmstudio' });
     expect(registry.get('anthropic-api')).toMatchObject({ id: 'anthropic-api' });
+  });
+
+  it('keeps local CLI adapters in the direct distribution', () => {
+    const settingsManager = {
+      hasApiKey: vi.fn(async () => false),
+      getApiKey: vi.fn(async () => null),
+    } as never;
+    const registry = createDefaultAnalysisProviderRegistry(settingsManager, {
+      distribution: 'direct',
+    });
+
+    expect(registry.get('codex-cli')).not.toBeInstanceOf(BridgeCliProvider);
+    expect(registry.get('opencode-cli')).not.toBeInstanceOf(BridgeCliProvider);
   });
 });

--- a/tests/unit/ai/bridgeCliProvider.test.ts
+++ b/tests/unit/ai/bridgeCliProvider.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { Session } from '../../../src/main/SessionController';
+import type { CliBridgeClient } from '../../../src/main/ai/bridge/CliBridgeClient';
+import { CliBridgeClientError } from '../../../src/main/ai/bridge/CliBridgeClient';
+import { BridgeCliProvider } from '../../../src/main/ai/bridge/BridgeCliProvider';
+
+const session = {
+  id: 'session-1', startTime: 1, state: 'complete', sourceId: 'screen:0:0',
+  feedbackItems: [], transcriptBuffer: [], screenshotBuffer: [],
+  metadata: { sourceId: 'screen:0:0', sourceName: 'Browser' },
+} as Session;
+
+function client(overrides: Partial<CliBridgeClient> = {}): CliBridgeClient {
+  return {
+    getHealth: vi.fn(),
+    discoverProviders: vi.fn(async () => [{
+      id: 'codex-cli', name: 'Codex CLI', connection: 'cli', installed: true, ready: true,
+    }]),
+    testProvider: vi.fn(async () => ({
+      id: 'codex-cli', name: 'Codex CLI', connection: 'cli', installed: true, ready: true,
+    })),
+    models: vi.fn(async () => [{ id: '', name: 'Codex default', source: 'default' }]),
+    analyze: vi.fn(async () => ({
+      summary: 'One issue.', items: [], themes: [], positiveNotes: [],
+      metadata: { totalItems: 0, criticalCount: 0, highCount: 0 },
+    })),
+    ...overrides,
+  } as never;
+}
+
+describe('BridgeCliProvider', () => {
+  it('forwards discovery, models, and analysis through one bridge client', async () => {
+    const bridgeClient = client();
+    const provider = new BridgeCliProvider('codex-cli', 'Codex CLI', bridgeClient);
+
+    await expect(provider.discover(false)).resolves.toMatchObject({ id: 'codex-cli', ready: true });
+    await expect(provider.discover(true)).resolves.toMatchObject({ id: 'codex-cli', ready: true });
+    await expect(provider.analyze(session, 'gpt-5.6')).resolves.toMatchObject({ summary: 'One issue.' });
+    expect(bridgeClient.testProvider).toHaveBeenCalledWith('codex-cli');
+    expect(bridgeClient.analyze).toHaveBeenCalledWith('codex-cli', session, 'gpt-5.6');
+  });
+
+  it.each([
+    ['BRIDGE_NOT_PAIRED', 'Pair MarkuprPlus CLI Bridge'],
+    ['BRIDGE_OFFLINE', 'Start MarkuprPlus CLI Bridge'],
+    ['BRIDGE_INCOMPATIBLE', 'Update MarkuprPlus CLI Bridge'],
+  ] as const)('turns %s into an actionable unavailable status', async (code, diagnostic) => {
+    const provider = new BridgeCliProvider('codex-cli', 'Codex CLI', client({
+      discoverProviders: vi.fn(async () => {
+        throw new CliBridgeClientError(code, 'transport detail');
+      }),
+    }));
+
+    await expect(provider.discover()).resolves.toMatchObject({
+      id: 'codex-cli',
+      installed: false,
+      ready: false,
+      diagnostic: expect.stringContaining(diagnostic),
+    });
+  });
+});

--- a/tests/unit/ai/cliBridgeClient.test.ts
+++ b/tests/unit/ai/cliBridgeClient.test.ts
@@ -1,0 +1,168 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { Session } from '../../../src/main/SessionController';
+import {
+  CliBridgeClient,
+  CliBridgeClientError,
+} from '../../../src/main/ai/bridge/CliBridgeClient';
+
+const session: Session = {
+  id: 'client-session',
+  startTime: 1_700_000_000_000,
+  state: 'complete',
+  sourceId: 'screen:0:0',
+  feedbackItems: [],
+  transcriptBuffer: [{
+    text: 'The button is clipped.',
+    isFinal: true,
+    confidence: 0.9,
+    timestamp: 1_700_000_001,
+    tier: 'whisper',
+  }],
+  screenshotBuffer: [],
+  metadata: {
+    sourceId: 'screen:0:0',
+    sourceName: 'Browser',
+    recordingPath: '/private/session.webm',
+  },
+};
+
+const providerStatus = {
+  id: 'codex-cli',
+  name: 'Codex CLI',
+  connection: 'cli' as const,
+  installed: true,
+  authenticated: true,
+  ready: true,
+  models: [{ id: '', name: 'Codex default', source: 'default' as const }],
+};
+
+const analysis = {
+  summary: 'One issue.',
+  items: [],
+  themes: [],
+  positiveNotes: [],
+  metadata: { totalItems: 0, criticalCount: 0, highCount: 0 },
+};
+
+describe('CliBridgeClient', () => {
+  it('does not issue authenticated requests without a paired token', async () => {
+    const fetchFn = vi.fn();
+    const client = new CliBridgeClient({
+      getToken: async () => null,
+      fetchFn,
+    });
+
+    await expect(client.discoverProviders()).rejects.toMatchObject({
+      code: 'BRIDGE_NOT_PAIRED',
+    });
+    expect(fetchFn).not.toHaveBeenCalled();
+  });
+
+  it('authenticates discovery, caches it, and bypasses cache for refresh', async () => {
+    const fetchFn = vi.fn(async () => new Response(JSON.stringify({
+      protocolVersion: 1,
+      providers: [providerStatus],
+    }), { status: 200, headers: { 'Content-Type': 'application/json' } }));
+    const client = new CliBridgeClient({
+      getToken: async () => 'j'.repeat(43),
+      fetchFn,
+      baseUrl: 'http://127.0.0.1:49647',
+    });
+
+    await expect(client.discoverProviders()).resolves.toEqual([providerStatus]);
+    await expect(client.discoverProviders()).resolves.toEqual([providerStatus]);
+    await expect(client.discoverProviders(true)).resolves.toEqual([providerStatus]);
+
+    expect(fetchFn).toHaveBeenCalledTimes(2);
+    const [url, options] = fetchFn.mock.calls[0];
+    expect(url).toBe('http://127.0.0.1:49647/v1/providers?force=false');
+    expect(options?.headers).toMatchObject({ Authorization: `Bearer ${'j'.repeat(43)}` });
+  });
+
+  it('enforces discovery timeouts and reports incompatible protocol versions', async () => {
+    const stalled = new CliBridgeClient({
+      getToken: async () => 'k'.repeat(43),
+      discoveryTimeoutMs: 10,
+      fetchFn: vi.fn((_url, options) => new Promise((_resolve, reject) => {
+        options?.signal?.addEventListener('abort', () => {
+          reject(Object.assign(new Error('aborted'), { name: 'AbortError' }));
+        });
+      })),
+    });
+    await expect(stalled.discoverProviders()).rejects.toMatchObject({ code: 'BRIDGE_OFFLINE' });
+
+    const incompatible = new CliBridgeClient({
+      getToken: async () => 'k'.repeat(43),
+      fetchFn: vi.fn(async () => new Response(JSON.stringify({
+        protocolVersion: 2,
+        providers: [],
+      }), { status: 200 })),
+    });
+    await expect(incompatible.discoverProviders()).rejects.toMatchObject({
+      code: 'BRIDGE_INCOMPATIBLE',
+    });
+  });
+
+  it('maps authenticated errors and malformed responses without leaking bodies', async () => {
+    const denied = new CliBridgeClient({
+      getToken: async () => 'l'.repeat(43),
+      fetchFn: vi.fn(async () => new Response(JSON.stringify({
+        error: { code: 'AUTH_INVALID', message: 'Bridge authentication failed.' },
+      }), { status: 401 })),
+    });
+    await expect(denied.discoverProviders()).rejects.toEqual(expect.objectContaining({
+      code: 'AUTH_INVALID',
+      status: 401,
+    }));
+
+    const malformed = new CliBridgeClient({
+      getToken: async () => 'l'.repeat(43),
+      fetchFn: vi.fn(async () => new Response('<html>secret response</html>', { status: 200 })),
+    });
+    await expect(malformed.discoverProviders()).rejects.toEqual(expect.objectContaining({
+      code: 'BRIDGE_PROTOCOL_ERROR',
+      message: expect.not.stringContaining('secret response'),
+    }));
+  });
+
+  it('sends a path-free analysis request and returns typed analysis', async () => {
+    let body = '';
+    const client = new CliBridgeClient({
+      getToken: async () => 'm'.repeat(43),
+      fetchFn: vi.fn(async (_url, options) => {
+        body = String(options?.body);
+        return new Response(JSON.stringify({ protocolVersion: 1, analysis }), { status: 200 });
+      }),
+    });
+
+    await expect(client.analyze('codex-cli', session, 'gpt-5.6')).resolves.toEqual(analysis);
+    expect(body).not.toContain('/private/session.webm');
+    expect(JSON.parse(body)).toMatchObject({
+      protocolVersion: 1,
+      provider: 'codex-cli',
+      modelId: 'gpt-5.6',
+      session: { id: 'client-session', metadata: { sourceName: 'Browser' } },
+    });
+  });
+
+  it('uses a candidate token without persisting it during pairing validation', async () => {
+    const getToken = vi.fn(async () => null);
+    const fetchFn = vi.fn(async () => new Response(JSON.stringify({
+      protocolVersion: 1,
+      providers: [providerStatus],
+    }), { status: 200 }));
+    const client = new CliBridgeClient({ getToken, fetchFn });
+
+    await client.discoverProviders(true, 'n'.repeat(43));
+    expect(getToken).not.toHaveBeenCalled();
+    expect(fetchFn.mock.calls[0][1]?.headers).toMatchObject({
+      Authorization: `Bearer ${'n'.repeat(43)}`,
+    });
+  });
+
+  it('uses a stable error class for bridge failures', () => {
+    const error = new CliBridgeClientError('BRIDGE_OFFLINE', 'Bridge offline.');
+    expect(error).toBeInstanceOf(Error);
+    expect(error).toMatchObject({ name: 'CliBridgeClientError', code: 'BRIDGE_OFFLINE' });
+  });
+});

--- a/tests/unit/analysisProviderOptions.test.ts
+++ b/tests/unit/analysisProviderOptions.test.ts
@@ -32,15 +32,30 @@ describe('analysis provider options', () => {
     ]);
   });
 
-  it('hides CLI cards in the Store distribution', () => {
+  it('shows CLI cards through the companion bridge in the Store distribution', () => {
     expect(providerOptionsForDistribution('mas').map(({ id }) => id)).toEqual([
+      'codex-cli',
+      'claude-cli',
+      'opencode-cli',
+      'cursor-cli',
+      'qwen-cli',
+      'goose-cli',
+      'amp-cli',
+      'kiro-cli',
+      'aider-cli',
       'ollama',
       'lmstudio',
       'anthropic-api',
       'rules',
     ]);
+    expect(providerOptionsForDistribution('mas')
+      .filter(({ connectionBadge }) => connectionBadge === 'CLI')
+      .every(({ description }) => description.includes('companion CLI Bridge'))).toBe(true);
     expect(providerOptionsForDistribution('direct').map(({ id }) => id)).toEqual(
       PROVIDER_OPTIONS.map(({ id }) => id),
+    );
+    expect(providerOptionsForDistribution('direct')[0].description).toBe(
+      'Use your installed Codex CLI and existing ChatGPT login.',
     );
   });
 

--- a/tests/unit/appStoreMetadata.test.ts
+++ b/tests/unit/appStoreMetadata.test.ts
@@ -67,6 +67,9 @@ describe('App Store public metadata', () => {
     expect(fields.description).not.toMatch(
       /\bpaid\b|open[ -]?source|free (?:on GitHub|direct-download)|MIT-licensed|direct-download edition/i,
     );
-    expect(fields.description).not.toMatch(/Codex CLI|Claude Code CLI/);
+    expect(fields.description).toMatch(/Codex CLI/);
+    expect(fields.description).toMatch(/optional local companion/i);
+    expect(fields.description).not.toMatch(/App Store app (?:directly )?(?:runs|executes|launches).*CLI/is);
+    expect(section(metadata, "What's New in Version 3.1.0").length).toBeLessThanOrEqual(4_000);
   });
 });

--- a/tests/unit/brandAudit.test.ts
+++ b/tests/unit/brandAudit.test.ts
@@ -13,7 +13,7 @@ type BrandVerifier = {
 const compatiblePackageJson = {
   name: 'markuprx',
   productName: 'MarkuprPlus',
-  version: '3.0.0',
+  version: '3.1.0',
   homepage: 'https://markuprplus.com',
   repository: {
     type: 'git',

--- a/tests/unit/bridgeCommand.test.ts
+++ b/tests/unit/bridgeCommand.test.ts
@@ -1,0 +1,75 @@
+import { Command } from 'commander';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  registerBridgeCommand,
+  type BridgeLifecycle,
+} from '../../src/bridge/BridgeCommand';
+
+function lifecycle(): BridgeLifecycle {
+  return {
+    install: vi.fn(async () => ({ token: 'h'.repeat(43), created: true })),
+    serve: vi.fn(async () => undefined),
+    start: vi.fn(async () => undefined),
+    stop: vi.fn(async () => undefined),
+    status: vi.fn(async () => ({ installed: true, running: true, protocolVersion: 1 })),
+    token: vi.fn(async () => 'h'.repeat(43)),
+    rotateToken: vi.fn(async () => 'i'.repeat(43)),
+    uninstall: vi.fn(async () => undefined),
+  };
+}
+
+async function run(
+  args: string[],
+  bridgeLifecycle: BridgeLifecycle,
+): Promise<{ output: string[]; errors: string[] }> {
+  const output: string[] = [];
+  const errors: string[] = [];
+  const program = new Command();
+  program.exitOverride();
+  registerBridgeCommand(program, {
+    lifecycle: bridgeLifecycle,
+    write: (line) => output.push(line),
+    writeError: (line) => errors.push(line),
+  });
+  await program.parseAsync(['node', 'markuprx', 'bridge', ...args]);
+  return { output, errors };
+}
+
+describe('markuprx bridge commands', () => {
+  let bridgeLifecycle: BridgeLifecycle;
+
+  beforeEach(() => {
+    bridgeLifecycle = lifecycle();
+  });
+
+  it('installs and prints the new pairing token only from explicit setup', async () => {
+    const result = await run(['install'], bridgeLifecycle);
+    expect(result.output.join('\n')).toContain('h'.repeat(43));
+    expect(result.output.join('\n')).toContain('Pairing token');
+    expect(bridgeLifecycle.install).toHaveBeenCalledOnce();
+  });
+
+  it('reports status without retrieving or printing the token', async () => {
+    const result = await run(['status'], bridgeLifecycle);
+    expect(result.output.join('\n')).toContain('Installed: yes');
+    expect(result.output.join('\n')).toContain('Running: yes');
+    expect(result.output.join('\n')).not.toContain('h'.repeat(43));
+    expect(bridgeLifecycle.token).not.toHaveBeenCalled();
+  });
+
+  it('exposes the token and rotation only through explicit commands', async () => {
+    expect((await run(['token'], bridgeLifecycle)).output).toEqual(['h'.repeat(43)]);
+    expect((await run(['rotate-token'], bridgeLifecycle)).output.join('\n'))
+      .toContain('i'.repeat(43));
+  });
+
+  it.each([
+    ['serve', 'serve'],
+    ['start', 'start'],
+    ['stop', 'stop'],
+    ['uninstall', 'uninstall'],
+  ] as const)('routes %s to the lifecycle', async (command, method) => {
+    await run([command], bridgeLifecycle);
+    expect(bridgeLifecycle[method]).toHaveBeenCalledOnce();
+  });
+});

--- a/tests/unit/bridgeConfig.test.ts
+++ b/tests/unit/bridgeConfig.test.ts
@@ -1,0 +1,73 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { mkdtemp, readFile, rm, stat, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  loadOrCreateBridgeConfig,
+  readBridgeConfig,
+  resolveBridgePaths,
+  rotateBridgeToken,
+} from '../../src/bridge/BridgeConfig';
+
+const roots: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+
+describe('CLI bridge configuration', () => {
+  it('resolves only the current user bridge and LaunchAgent paths', () => {
+    expect(resolveBridgePaths('/Users/example')).toEqual({
+      stateDirectory: '/Users/example/.config/markuprplus/bridge',
+      configPath: '/Users/example/.config/markuprplus/bridge/config.json',
+      stdoutLogPath: '/Users/example/.config/markuprplus/bridge/stdout.log',
+      stderrLogPath: '/Users/example/.config/markuprplus/bridge/stderr.log',
+      launchAgentPath:
+        '/Users/example/Library/LaunchAgents/com.trieflow.markuprplus.cli-bridge.plist',
+    });
+  });
+
+  it('creates a mode-restricted config and retains its valid token', async () => {
+    const home = await mkdtemp(join(tmpdir(), 'markuprplus-bridge-config-'));
+    roots.push(home);
+    const paths = resolveBridgePaths(home);
+    const first = await loadOrCreateBridgeConfig(paths, {
+      generateToken: () => 'c'.repeat(43),
+    });
+    const second = await loadOrCreateBridgeConfig(paths, {
+      generateToken: () => 'd'.repeat(43),
+    });
+
+    expect(first).toEqual({
+      config: { token: 'c'.repeat(43), protocolVersion: 1, port: 49_647 },
+      created: true,
+    });
+    expect(second).toEqual({ config: first.config, created: false });
+    expect((await stat(paths.stateDirectory)).mode & 0o777).toBe(0o700);
+    expect((await stat(paths.configPath)).mode & 0o777).toBe(0o600);
+  });
+
+  it('rejects malformed configuration instead of silently replacing it', async () => {
+    const home = await mkdtemp(join(tmpdir(), 'markuprplus-bridge-config-'));
+    roots.push(home);
+    const paths = resolveBridgePaths(home);
+    await loadOrCreateBridgeConfig(paths, { generateToken: () => 'e'.repeat(43) });
+    await writeFile(paths.configPath, '{"token":"short"}\n', { mode: 0o600 });
+
+    await expect(readBridgeConfig(paths)).rejects.toThrow(/invalid CLI bridge configuration/i);
+    await expect(loadOrCreateBridgeConfig(paths)).rejects.toThrow(/invalid CLI bridge configuration/i);
+    expect(await readFile(paths.configPath, 'utf8')).toBe('{"token":"short"}\n');
+  });
+
+  it('rotates only the token while preserving protocol and port', async () => {
+    const home = await mkdtemp(join(tmpdir(), 'markuprplus-bridge-config-'));
+    roots.push(home);
+    const paths = resolveBridgePaths(home);
+    await loadOrCreateBridgeConfig(paths, { generateToken: () => 'f'.repeat(43) });
+
+    const rotated = await rotateBridgeToken(paths, () => 'g'.repeat(43));
+    expect(rotated).toEqual({ token: 'g'.repeat(43), protocolVersion: 1, port: 49_647 });
+    await expect(readBridgeConfig(paths)).resolves.toEqual(rotated);
+    expect((await stat(paths.configPath)).mode & 0o777).toBe(0o600);
+  });
+});

--- a/tests/unit/bridgeLaunchAgent.test.ts
+++ b/tests/unit/bridgeLaunchAgent.test.ts
@@ -12,13 +12,13 @@ describe('CLI bridge LaunchAgent', () => {
   it('renders an escaped per-user launchd service with no token', () => {
     const plist = renderBridgeLaunchAgent({
       nodePath: '/opt/homebrew/bin/node',
-      cliPath: '/Users/tester/Markupr & Tools/dist/cli/index.mjs',
+      cliPath: '/Users/tester/CLI & Tools/dist/cli/index.mjs',
       paths,
     });
 
     expect(plist).toContain('<string>com.trieflow.markuprplus.cli-bridge</string>');
     expect(plist).toContain('<string>/opt/homebrew/bin/node</string>');
-    expect(plist).toContain('<string>/Users/tester/Markupr &amp; Tools/dist/cli/index.mjs</string>');
+    expect(plist).toContain('<string>/Users/tester/CLI &amp; Tools/dist/cli/index.mjs</string>');
     expect(plist).toContain('<string>bridge</string>');
     expect(plist).toContain('<string>serve</string>');
     expect(plist).toContain('<key>RunAtLoad</key>');

--- a/tests/unit/bridgeLaunchAgent.test.ts
+++ b/tests/unit/bridgeLaunchAgent.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest';
+import {
+  planBridgeInstall,
+  planBridgeUninstall,
+  renderBridgeLaunchAgent,
+} from '../../src/bridge/BridgeLaunchAgent';
+import { resolveBridgePaths } from '../../src/bridge/BridgeConfig';
+
+const paths = resolveBridgePaths('/Users/tester');
+
+describe('CLI bridge LaunchAgent', () => {
+  it('renders an escaped per-user launchd service with no token', () => {
+    const plist = renderBridgeLaunchAgent({
+      nodePath: '/opt/homebrew/bin/node',
+      cliPath: '/Users/tester/Markupr & Tools/dist/cli/index.mjs',
+      paths,
+    });
+
+    expect(plist).toContain('<string>com.trieflow.markuprplus.cli-bridge</string>');
+    expect(plist).toContain('<string>/opt/homebrew/bin/node</string>');
+    expect(plist).toContain('<string>/Users/tester/Markupr &amp; Tools/dist/cli/index.mjs</string>');
+    expect(plist).toContain('<string>bridge</string>');
+    expect(plist).toContain('<string>serve</string>');
+    expect(plist).toContain('<key>RunAtLoad</key>');
+    expect(plist).toContain('<key>KeepAlive</key>');
+    expect(plist).not.toContain('Bearer');
+    expect(plist).not.toContain('token');
+  });
+
+  it('plans idempotent bootout/bootstrap commands in the current GUI domain', () => {
+    expect(planBridgeInstall({
+      platform: 'darwin',
+      uid: 501,
+      nodePath: '/opt/homebrew/bin/node',
+      cliPath: '/opt/homebrew/lib/node_modules/markuprx/dist/cli/index.mjs',
+      paths,
+    })).toMatchObject({
+      plistPath: paths.launchAgentPath,
+      bootoutArgs: ['bootout', 'gui/501/com.trieflow.markuprplus.cli-bridge'],
+      bootstrapArgs: ['bootstrap', 'gui/501', paths.launchAgentPath],
+      kickstartArgs: ['kickstart', '-k', 'gui/501/com.trieflow.markuprplus.cli-bridge'],
+    });
+  });
+
+  it('rejects unsupported platforms, relative executables, and npx caches', () => {
+    expect(() => planBridgeInstall({
+      platform: 'linux', uid: 501, nodePath: '/usr/bin/node', cliPath: '/opt/markuprx/index.mjs', paths,
+    })).toThrow(/macOS/i);
+    expect(() => planBridgeInstall({
+      platform: 'darwin', uid: 501, nodePath: 'node', cliPath: '/opt/markuprx/index.mjs', paths,
+    })).toThrow(/absolute/i);
+    expect(() => planBridgeInstall({
+      platform: 'darwin',
+      uid: 501,
+      nodePath: '/usr/bin/node',
+      cliPath: '/Users/tester/.npm/_npx/abc/node_modules/markuprx/dist/cli/index.mjs',
+      paths,
+    })).toThrow(/temporary npx cache/i);
+  });
+
+  it('limits uninstall to the exact bridge-owned plist and config files', () => {
+    expect(planBridgeUninstall({ platform: 'darwin', uid: 501, paths })).toEqual({
+      bootoutArgs: ['bootout', 'gui/501/com.trieflow.markuprplus.cli-bridge'],
+      filesToRemove: [paths.launchAgentPath, paths.configPath],
+    });
+  });
+});

--- a/tests/unit/bridgeSession.test.ts
+++ b/tests/unit/bridgeSession.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from 'vitest';
+import type { Session } from '../../src/main/SessionController';
+import {
+  deserializeBridgeSession,
+  serializeBridgeSession,
+} from '../../src/bridge/BridgeSession';
+
+const png = Buffer.from([
+  0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
+  0x00, 0x00, 0x00, 0x0d,
+]);
+
+describe('bridge session transport', () => {
+  it('round-trips analyzer input while removing filesystem paths', () => {
+    const session: Session = {
+      id: 'session-1',
+      startTime: 1_700_000_000_000,
+      endTime: 1_700_000_010_000,
+      state: 'complete',
+      sourceId: 'window:1:0',
+      feedbackItems: [{
+        id: 'feedback-1',
+        timestamp: 1_700_000_002_000,
+        text: 'The button is clipped.',
+        confidence: 0.92,
+      }],
+      transcriptBuffer: [{
+        text: 'The button is clipped.',
+        isFinal: true,
+        confidence: 0.92,
+        timestamp: 1_700_000_002,
+        tier: 'whisper',
+      }],
+      screenshotBuffer: [{
+        id: 'shot-1',
+        timestamp: 1_700_000_002_000,
+        buffer: png,
+        width: 1280,
+        height: 720,
+      }],
+      metadata: {
+        sourceId: 'window:1:0',
+        sourceName: 'Example App',
+        sourceType: 'window',
+        recordingPath: '/Users/example/private/session.webm',
+        audioPath: '/Users/example/private/session.wav',
+        markedIssues: [{
+          id: 'issue-1',
+          ordinal: 1,
+          startedAt: 1_700_000_001_000,
+          markedAt: 1_700_000_002_000,
+          completedAt: 1_700_000_003_000,
+          strokeIds: ['stroke-1'],
+          tools: ['circle'],
+          colors: ['#ff3b30'],
+          screenshotPath: '/Users/example/private/shot.png',
+          fallbackVideoTimestamp: 2_000,
+          comment: 'The button is clipped.',
+          transcriptionStatus: 'available',
+          snapshotRevision: 1,
+          transcriptSegmentIds: ['transcript-segment-0001'],
+        }],
+      },
+    };
+
+    const payload = serializeBridgeSession(session);
+    const encoded = JSON.stringify(payload);
+
+    expect(encoded).not.toContain('/Users/example');
+    expect(encoded).not.toContain('recordingPath');
+    expect(encoded).not.toContain('audioPath');
+    expect(encoded).not.toContain('screenshotPath');
+    expect(payload.screenshots[0]).toMatchObject({
+      id: 'shot-1',
+      mimeType: 'image/png',
+      dataBase64: png.toString('base64'),
+    });
+
+    const restored = deserializeBridgeSession(payload);
+    expect(restored).toMatchObject({
+      id: 'session-1',
+      sourceId: 'window:1:0',
+      state: 'complete',
+      metadata: {
+        sourceName: 'Example App',
+        markedIssues: [{ id: 'issue-1', comment: 'The button is clipped.' }],
+      },
+      transcriptBuffer: [{ text: 'The button is clipped.', isFinal: true }],
+    });
+    expect(restored.screenshotBuffer[0].buffer).toEqual(png);
+  });
+
+  it('detects JPEG screenshot bytes without trusting a caller-provided path', () => {
+    const jpeg = Buffer.from([0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10]);
+    const session: Session = {
+      id: 'jpeg-session',
+      startTime: 10,
+      state: 'complete',
+      sourceId: 'screen:0:0',
+      feedbackItems: [],
+      transcriptBuffer: [],
+      screenshotBuffer: [{
+        id: 'jpeg-shot', timestamp: 20, buffer: jpeg, width: 10, height: 10,
+      }],
+      metadata: { sourceId: 'screen:0:0', sourceName: 'Screen' },
+    };
+
+    expect(serializeBridgeSession(session).screenshots[0].mimeType).toBe('image/jpeg');
+  });
+});

--- a/tests/unit/captureMomentHints.test.ts
+++ b/tests/unit/captureMomentHints.test.ts
@@ -4,7 +4,9 @@ import {
   attachFallbackFramesToMarkedIssues,
   captureContextsToKeyMoments,
   nearestCaptureContext,
+  removeClaimedTranscriptFrames,
 } from '../../src/main/pipeline/CaptureMomentHints';
+import type { ExtractedFrame, TranscriptSegment } from '../../src/main/pipeline/PostProcessor';
 
 const annotationContext: CaptureContextSnapshot = {
   recordedAt: 11_000,
@@ -93,6 +95,44 @@ describe('CaptureMomentHints', () => {
         ...missing,
         evidenceWarning: 'No marked screenshot could be recovered for this issue.',
       },
+    ]);
+  });
+
+  it('removes generic frames for narration already owned by a marked issue', () => {
+    const segments: TranscriptSegment[] = [{
+      text: 'Marked checkout issue',
+      startTime: 0,
+      endTime: 2,
+      confidence: 1,
+    }, {
+      text: 'Unmarked navigation feedback',
+      startTime: 3,
+      endTime: 5,
+      confidence: 1,
+    }];
+    const issue = markedIssue(1, 1, 'screenshots/marked-issue-001.png');
+    issue.transcriptSegmentIds = ['transcript-segment-0001'];
+    const frames: ExtractedFrame[] = [{
+      path: '/tmp/frame-start.png',
+      timestamp: 0.35,
+      reason: 'Session start',
+      transcriptSegment: segments[0],
+    }, {
+      path: '/tmp/frame-marked-fallback.png',
+      timestamp: 1,
+      reason: 'Marked issue',
+      markedIssueId: issue.id,
+      transcriptSegment: segments[0],
+    }, {
+      path: '/tmp/frame-unclaimed.png',
+      timestamp: 4,
+      reason: 'AI-highlighted context',
+      transcriptSegment: segments[1],
+    }];
+
+    expect(removeClaimedTranscriptFrames(frames, segments, [issue])).toEqual([
+      frames[1],
+      frames[2],
     ]);
   });
 });

--- a/tests/unit/cliBridgeBuild.test.ts
+++ b/tests/unit/cliBridgeBuild.test.ts
@@ -1,0 +1,32 @@
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { describe, expect, it } from 'vitest';
+
+const execFileAsync = promisify(execFile);
+
+describe('published CLI bridge bundle', () => {
+  it('exposes every companion lifecycle command from the built CLI', async () => {
+    await execFileAsync(process.execPath, ['scripts/build-cli.mjs'], {
+      cwd: process.cwd(),
+      timeout: 30_000,
+    });
+    const { stdout } = await execFileAsync(
+      process.execPath,
+      ['dist/cli/index.mjs', 'bridge', '--help'],
+      { cwd: process.cwd(), timeout: 10_000 },
+    );
+
+    for (const command of [
+      'install',
+      'serve',
+      'start',
+      'stop',
+      'status',
+      'token',
+      'rotate-token',
+      'uninstall',
+    ]) {
+      expect(stdout).toContain(command);
+    }
+  });
+});

--- a/tests/unit/cliBridgeDocumentation.test.ts
+++ b/tests/unit/cliBridgeDocumentation.test.ts
@@ -27,7 +27,9 @@ describe('CLI Bridge release documentation', () => {
   it('documents the complete optional companion lifecycle and fixed loopback endpoint', async () => {
     const readme = await readFile('README.md', 'utf8');
     expect(readme).toMatch(/optional.*companion/is);
-    expect(readme).toContain('npm install -g markuprx@latest');
+    expect(readme).toContain(
+      'npm install -g https://github.com/hashfunction/MarkuprPlus/releases/download/v3.1.0/markuprx-3.1.0.tgz',
+    );
     for (const command of lifecycleCommands) expect(readme).toContain(command);
     expect(readme).toContain('127.0.0.1:49647');
     expect(readme).toMatch(/App Store app does not (?:run|execute|launch) shell commands/i);
@@ -48,6 +50,9 @@ describe('CLI Bridge release documentation', () => {
     }
     expect(metadata).toContain("## What's New in Version 3.1.0");
     expect(reviewNotes).toContain('# App Review Notes — MarkuprPlus 3.1.0');
+    expect(reviewNotes).toContain(
+      'https://github.com/hashfunction/MarkuprPlus/releases/download/v3.1.0/markuprx-3.1.0.tgz',
+    );
     expect(reviewNotes.indexOf('Local Rules')).toBeLessThan(reviewNotes.indexOf('Optional CLI Bridge'));
     expect(reviewNotes).toMatch(/does not execute external.*inside.*sandbox/is);
     expect(privacyPage).toMatch(/transcript.*selected screenshots.*companion/is);

--- a/tests/unit/cliBridgeDocumentation.test.ts
+++ b/tests/unit/cliBridgeDocumentation.test.ts
@@ -1,0 +1,56 @@
+import { readFile } from 'node:fs/promises';
+import { describe, expect, it } from 'vitest';
+
+const lifecycleCommands = [
+  'markuprx bridge install',
+  'markuprx bridge start',
+  'markuprx bridge status',
+  'markuprx bridge token',
+  'markuprx bridge rotate-token',
+  'markuprx bridge uninstall',
+];
+
+describe('CLI Bridge release documentation', () => {
+  it('sets version 3.1.0 and Mac App Store build 3', async () => {
+    const [packageJson, lockJson, masConfig] = await Promise.all([
+      readFile('package.json', 'utf8').then(JSON.parse),
+      readFile('package-lock.json', 'utf8').then(JSON.parse),
+      readFile('electron-builder.mas.yml', 'utf8'),
+    ]);
+
+    expect(packageJson.version).toBe('3.1.0');
+    expect(lockJson.version).toBe('3.1.0');
+    expect(lockJson.packages[''].version).toBe('3.1.0');
+    expect(masConfig).toMatch(/^buildVersion: "3"$/m);
+  });
+
+  it('documents the complete optional companion lifecycle and fixed loopback endpoint', async () => {
+    const readme = await readFile('README.md', 'utf8');
+    expect(readme).toMatch(/optional.*companion/is);
+    expect(readme).toContain('npm install -g markuprx@latest');
+    for (const command of lifecycleCommands) expect(readme).toContain(command);
+    expect(readme).toContain('127.0.0.1:49647');
+    expect(readme).toMatch(/App Store app does not (?:run|execute|launch) shell commands/i);
+  });
+
+  it('discloses bridge data flow in Store copy, privacy copy, and review notes', async () => {
+    const [metadata, reviewNotes, privacyAnswers, privacyPage, changelog] = await Promise.all([
+      readFile('app-store/metadata/en-US.md', 'utf8'),
+      readFile('app-store/review-notes.md', 'utf8'),
+      readFile('app-store/privacy-answers.md', 'utf8'),
+      readFile('site/privacy.html', 'utf8'),
+      readFile('CHANGELOG.md', 'utf8'),
+    ]);
+
+    for (const content of [metadata, reviewNotes, privacyAnswers, privacyPage]) {
+      expect(content).toMatch(/companion/i);
+      expect(content).toMatch(/(?:localhost|loopback|127\.0\.0\.1)/i);
+    }
+    expect(metadata).toContain("## What's New in Version 3.1.0");
+    expect(reviewNotes).toContain('# App Review Notes — MarkuprPlus 3.1.0');
+    expect(reviewNotes.indexOf('Local Rules')).toBeLessThan(reviewNotes.indexOf('Optional CLI Bridge'));
+    expect(reviewNotes).toMatch(/does not execute external.*inside.*sandbox/is);
+    expect(privacyPage).toMatch(/transcript.*selected screenshots.*companion/is);
+    expect(changelog).toMatch(/^## 3\.1\.0 - 2026-08-30$/m);
+  });
+});

--- a/tests/unit/cliBridgeIpc.test.ts
+++ b/tests/unit/cliBridgeIpc.test.ts
@@ -1,0 +1,162 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ipcMain } from 'electron';
+import { registerCliBridgeHandlers } from '../../src/main/ipc/cliBridgeHandlers';
+import { CliBridgeClientError } from '../../src/main/ai/bridge/CliBridgeClient';
+import { IPC_CHANNELS, type AnalysisProviderStatus } from '../../src/shared/types';
+import type { IpcContext } from '../../src/main/ipc/types';
+
+const PROVIDERS: AnalysisProviderStatus[] = [{
+  id: 'codex-cli',
+  name: 'Codex CLI',
+  connection: 'cli',
+  installed: true,
+  authenticated: true,
+  ready: true,
+}];
+
+function registeredHandler(channel: string): (...args: unknown[]) => unknown {
+  const registration = vi.mocked(ipcMain.handle).mock.calls.find(([name]) => name === channel);
+  if (!registration) throw new Error(`Handler not registered for ${channel}`);
+  return registration[1] as (...args: unknown[]) => unknown;
+}
+
+function setup(options: {
+  distribution?: 'direct' | 'mas';
+  token?: string | null;
+  provider?: string;
+  discover?: ReturnType<typeof vi.fn>;
+} = {}) {
+  const getApiKey = vi.fn(async () => options.token ?? null);
+  const setApiKey = vi.fn(async () => undefined);
+  const deleteApiKey = vi.fn(async () => undefined);
+  const set = vi.fn();
+  const get = vi.fn((key: string) => key === 'analysisProvider'
+    ? options.provider ?? 'anthropic-api'
+    : undefined);
+  const discoverProviders = options.discover ?? vi.fn(async () => PROVIDERS);
+  const context: IpcContext = {
+    getMainWindow: () => null,
+    getPopover: () => null,
+    getSettingsManager: () => ({ getApiKey, setApiKey, deleteApiKey, set, get } as never),
+    getWindowsTaskbar: () => null,
+    getHasCompletedOnboarding: () => true,
+    setHasCompletedOnboarding: () => undefined,
+  };
+
+  registerCliBridgeHandlers(context, {
+    distribution: () => options.distribution ?? 'mas',
+    createClient: () => ({ discoverProviders }),
+  });
+  return { getApiKey, setApiKey, deleteApiKey, set, get, discoverProviders };
+}
+
+describe('CLI bridge IPC', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('is not applicable in direct builds without reading secrets or contacting a bridge', async () => {
+    const deps = setup({ distribution: 'direct' });
+
+    await expect(registeredHandler(IPC_CHANNELS.CLI_BRIDGE_STATUS)({})).resolves.toEqual({
+      state: 'not-applicable',
+      paired: false,
+      diagnostic: 'CLI providers run directly in this build.',
+    });
+    expect(deps.getApiKey).not.toHaveBeenCalled();
+    expect(deps.discoverProviders).not.toHaveBeenCalled();
+  });
+
+  it('reports not paired without exposing or testing a saved token', async () => {
+    const deps = setup({ token: null });
+
+    await expect(registeredHandler(IPC_CHANNELS.CLI_BRIDGE_STATUS)({})).resolves.toEqual({
+      state: 'not-paired',
+      paired: false,
+      diagnostic: 'Pair MarkuprPlus CLI Bridge.',
+    });
+    expect(deps.discoverProviders).not.toHaveBeenCalled();
+  });
+
+  it('reports connected provider status using the saved secret only in main', async () => {
+    const deps = setup({ token: 'saved-secret' });
+
+    await expect(registeredHandler(IPC_CHANNELS.CLI_BRIDGE_STATUS)({})).resolves.toEqual({
+      state: 'connected',
+      paired: true,
+      providers: PROVIDERS,
+    });
+    expect(deps.discoverProviders).toHaveBeenCalledWith(false);
+  });
+
+  it('maps bridge connection failures to an actionable status', async () => {
+    setup({
+      token: 'saved-secret',
+      discover: vi.fn(async () => {
+        throw new CliBridgeClientError('BRIDGE_OFFLINE', 'Start MarkuprPlus CLI Bridge.');
+      }),
+    });
+
+    await expect(registeredHandler(IPC_CHANNELS.CLI_BRIDGE_STATUS)({})).resolves.toEqual({
+      state: 'offline',
+      paired: true,
+      diagnostic: 'Start MarkuprPlus CLI Bridge.',
+    });
+  });
+
+  it('rejects malformed pairing tokens before contacting or changing anything', async () => {
+    const deps = setup({ token: 'old-secret' });
+
+    await expect(registeredHandler(IPC_CHANNELS.CLI_BRIDGE_PAIR)({}, 'bad token')).resolves.toEqual({
+      success: false,
+      status: {
+        state: 'not-paired',
+        paired: true,
+        diagnostic: 'Enter the 43-character token printed by markuprplus bridge token.',
+      },
+    });
+    expect(deps.discoverProviders).not.toHaveBeenCalled();
+    expect(deps.setApiKey).not.toHaveBeenCalled();
+    expect(deps.deleteApiKey).not.toHaveBeenCalled();
+  });
+
+  it('validates a candidate token before saving it', async () => {
+    const deps = setup();
+    const candidate = 'a'.repeat(43);
+
+    await expect(registeredHandler(IPC_CHANNELS.CLI_BRIDGE_PAIR)({}, ` ${candidate} `)).resolves.toEqual({
+      success: true,
+      status: { state: 'connected', paired: true, providers: PROVIDERS },
+    });
+    expect(deps.discoverProviders).toHaveBeenCalledWith(true, candidate);
+    expect(deps.setApiKey).toHaveBeenCalledWith('cli-bridge', candidate);
+  });
+
+  it('preserves the previous pairing when candidate validation fails', async () => {
+    const deps = setup({
+      token: 'old-secret',
+      discover: vi.fn(async () => {
+        throw new CliBridgeClientError('AUTH_INVALID', 'Pairing token was rejected.');
+      }),
+    });
+
+    await expect(registeredHandler(IPC_CHANNELS.CLI_BRIDGE_PAIR)({}, 'a'.repeat(43))).resolves.toEqual({
+      success: false,
+      status: { state: 'not-paired', paired: true, diagnostic: 'Pairing token was rejected.' },
+    });
+    expect(deps.setApiKey).not.toHaveBeenCalled();
+    expect(deps.deleteApiKey).not.toHaveBeenCalled();
+  });
+
+  it('forgets the secret and falls back to Local Rules when a CLI was selected', async () => {
+    const deps = setup({ token: 'saved-secret', provider: 'codex-cli' });
+
+    await expect(registeredHandler(IPC_CHANNELS.CLI_BRIDGE_FORGET)({})).resolves.toEqual({
+      state: 'not-paired',
+      paired: false,
+      diagnostic: 'Pair MarkuprPlus CLI Bridge.',
+    });
+    expect(deps.deleteApiKey).toHaveBeenCalledWith('cli-bridge');
+    expect(deps.set).toHaveBeenCalledWith('analysisProvider', 'rules');
+  });
+});

--- a/tests/unit/cliBridgeIpc.test.ts
+++ b/tests/unit/cliBridgeIpc.test.ts
@@ -112,7 +112,7 @@ describe('CLI bridge IPC', () => {
       status: {
         state: 'not-paired',
         paired: true,
-        diagnostic: 'Enter the 43-character token printed by markuprplus bridge token.',
+        diagnostic: 'Enter the 43-character token printed by markuprx bridge token.',
       },
     });
     expect(deps.discoverProviders).not.toHaveBeenCalled();

--- a/tests/unit/cliBridgePreload.test.ts
+++ b/tests/unit/cliBridgePreload.test.ts
@@ -1,0 +1,52 @@
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { contextBridge, ipcRenderer } from 'electron';
+import type { CliBridgeConnectionStatus, CliBridgePairResult } from '../../src/shared/types';
+
+interface ExposedCliBridgeApi {
+  status(): Promise<CliBridgeConnectionStatus>;
+  pair(token: string): Promise<CliBridgePairResult>;
+  forget(): Promise<CliBridgeConnectionStatus>;
+}
+
+let cliBridge: ExposedCliBridgeApi;
+
+describe('CLI bridge preload API', () => {
+  beforeAll(async () => {
+    vi.resetModules();
+    await import('../../src/preload/index');
+    const exposure = vi.mocked(contextBridge.exposeInMainWorld).mock.calls.find(([name]) => name === 'markuprx');
+    if (!exposure) throw new Error('markuprx preload API was not exposed');
+    cliBridge = (exposure[1] as { cliBridge: ExposedCliBridgeApi }).cliBridge;
+  });
+
+  beforeEach(() => {
+    vi.mocked(ipcRenderer.invoke).mockReset();
+  });
+
+  it('gets connection status without accepting a token', async () => {
+    const status: CliBridgeConnectionStatus = { state: 'connected', paired: true, providers: [] };
+    vi.mocked(ipcRenderer.invoke).mockResolvedValue(status);
+
+    await expect(cliBridge.status()).resolves.toEqual(status);
+    expect(ipcRenderer.invoke).toHaveBeenCalledWith('markuprx:cli-bridge:status');
+  });
+
+  it('submits a candidate token through only the pairing channel', async () => {
+    const result: CliBridgePairResult = {
+      success: true,
+      status: { state: 'connected', paired: true, providers: [] },
+    };
+    vi.mocked(ipcRenderer.invoke).mockResolvedValue(result);
+
+    await expect(cliBridge.pair('candidate')).resolves.toEqual(result);
+    expect(ipcRenderer.invoke).toHaveBeenCalledWith('markuprx:cli-bridge:pair', 'candidate');
+  });
+
+  it('forgets the connection without naming or retrieving its secure-storage key', async () => {
+    const status: CliBridgeConnectionStatus = { state: 'not-paired', paired: false };
+    vi.mocked(ipcRenderer.invoke).mockResolvedValue(status);
+
+    await expect(cliBridge.forget()).resolves.toEqual(status);
+    expect(ipcRenderer.invoke).toHaveBeenCalledWith('markuprx:cli-bridge:forget');
+  });
+});

--- a/tests/unit/cliBridgeProtocol.test.ts
+++ b/tests/unit/cliBridgeProtocol.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from 'vitest';
+import {
+  CLI_BRIDGE_DEFAULT_HOST,
+  CLI_BRIDGE_DEFAULT_PORT,
+  CLI_BRIDGE_PROTOCOL_VERSION,
+  CLI_BRIDGE_PROVIDER_IDS,
+  parseBridgeAnalyzeRequest,
+  type BridgeAnalyzeRequest,
+  type BridgeSessionPayload,
+} from '../../src/shared/cliBridgeProtocol';
+
+const minimalSession: BridgeSessionPayload = {
+  id: 'bridge-session',
+  startTime: 1_700_000_000_000,
+  state: 'complete',
+  sourceId: 'screen:0:0',
+  feedbackItems: [],
+  transcriptBuffer: [],
+  screenshots: [],
+  metadata: {
+    sourceId: 'screen:0:0',
+    sourceName: 'Browser',
+    sourceType: 'screen',
+  },
+};
+
+function request(overrides: Partial<BridgeAnalyzeRequest> = {}): unknown {
+  return {
+    protocolVersion: 1,
+    provider: 'codex-cli',
+    session: minimalSession,
+    ...overrides,
+  };
+}
+
+describe('CLI bridge protocol', () => {
+  it('accepts only the supported CLI provider catalog', () => {
+    expect(CLI_BRIDGE_PROTOCOL_VERSION).toBe(1);
+    expect(CLI_BRIDGE_DEFAULT_HOST).toBe('127.0.0.1');
+    expect(CLI_BRIDGE_DEFAULT_PORT).toBe(49_647);
+    expect(CLI_BRIDGE_PROVIDER_IDS).toEqual([
+      'codex-cli',
+      'claude-cli',
+      'opencode-cli',
+      'cursor-cli',
+      'qwen-cli',
+      'goose-cli',
+      'amp-cli',
+      'kiro-cli',
+      'aider-cli',
+    ]);
+
+    expect(parseBridgeAnalyzeRequest(request())).toMatchObject({
+      protocolVersion: 1,
+      provider: 'codex-cli',
+      session: { id: 'bridge-session' },
+    });
+    expect(() => parseBridgeAnalyzeRequest(request({ provider: 'ollama' as never })))
+      .toThrow(/unsupported provider/i);
+  });
+
+  it('rejects unknown properties and unsafe model identifiers', () => {
+    expect(() => parseBridgeAnalyzeRequest({
+      ...request() as object,
+      executable: '/usr/local/bin/codex',
+    })).toThrow(/invalid bridge request/i);
+    expect(() => parseBridgeAnalyzeRequest(request({ modelId: 'bad\nmodel' })))
+      .toThrow(/invalid bridge request/i);
+    expect(() => parseBridgeAnalyzeRequest(request({ modelId: 'x'.repeat(201) })))
+      .toThrow(/invalid bridge request/i);
+  });
+
+  it('enforces screenshot count, encoding, and decoded byte limits', () => {
+    const screenshot = {
+      id: 'shot-1',
+      timestamp: 1_700_000_001_000,
+      width: 100,
+      height: 80,
+      mimeType: 'image/png' as const,
+      dataBase64: Buffer.from('png').toString('base64'),
+    };
+
+    expect(() => parseBridgeAnalyzeRequest(request({
+      session: { ...minimalSession, screenshots: Array.from({ length: 21 }, () => screenshot) },
+    }))).toThrow(/invalid bridge request/i);
+    expect(() => parseBridgeAnalyzeRequest(request({
+      session: {
+        ...minimalSession,
+        screenshots: [{ ...screenshot, dataBase64: '***not-base64***' }],
+      },
+    }))).toThrow(/invalid bridge request/i);
+    expect(() => parseBridgeAnalyzeRequest(request({
+      session: {
+        ...minimalSession,
+        screenshots: [{
+          ...screenshot,
+          dataBase64: Buffer.alloc(8 * 1024 * 1024 + 1).toString('base64'),
+        }],
+      },
+    }))).toThrow(/invalid bridge request/i);
+  });
+
+  it('bounds transcript and feedback arrays', () => {
+    const transcript = {
+      text: 'A note',
+      isFinal: true,
+      confidence: 0.9,
+      timestamp: 1_700_000_001,
+      tier: 'whisper' as const,
+    };
+    const feedback = {
+      id: 'feedback-1',
+      timestamp: 1_700_000_001_000,
+      text: 'A note',
+      confidence: 0.9,
+    };
+
+    expect(() => parseBridgeAnalyzeRequest(request({
+      session: {
+        ...minimalSession,
+        transcriptBuffer: Array.from({ length: 2_001 }, () => transcript),
+      },
+    }))).toThrow(/invalid bridge request/i);
+    expect(() => parseBridgeAnalyzeRequest(request({
+      session: {
+        ...minimalSession,
+        feedbackItems: Array.from({ length: 2_001 }, () => feedback),
+      },
+    }))).toThrow(/invalid bridge request/i);
+  });
+});

--- a/tests/unit/cliBridgeServer.test.ts
+++ b/tests/unit/cliBridgeServer.test.ts
@@ -1,0 +1,185 @@
+import { describe, expect, it, vi } from 'vitest';
+import { request as httpRequest } from 'node:http';
+import type { AIAnalysisResult } from '../../src/main/ai/types';
+import {
+  createAnalysisProviderRegistry,
+} from '../../src/main/ai/providers/AnalysisProviderRegistry';
+import type { AnalysisProviderAdapter } from '../../src/main/ai/providers/types';
+import {
+  generateBridgeToken,
+  isAuthorized,
+} from '../../src/bridge/BridgeAuth';
+import { startCliBridgeServer } from '../../src/bridge/CliBridgeServer';
+
+const token = 'a'.repeat(43);
+const analysis: AIAnalysisResult = {
+  summary: 'One issue found.',
+  items: [],
+  themes: [],
+  positiveNotes: [],
+  metadata: { totalItems: 0, criticalCount: 0, highCount: 0 },
+};
+
+function codexAdapter(): AnalysisProviderAdapter {
+  return {
+    id: 'codex-cli',
+    name: 'Codex CLI',
+    connection: 'cli',
+    discover: vi.fn(async () => ({
+      id: 'codex-cli',
+      name: 'Codex CLI',
+      connection: 'cli' as const,
+      installed: true,
+      authenticated: true,
+      ready: true,
+      version: 'codex 1.2.3',
+      executablePath: '/usr/local/bin/codex',
+      models: [{ id: '', name: 'Codex default', source: 'default' as const }],
+    })),
+    analyze: vi.fn(async () => analysis),
+  };
+}
+
+async function requestWithHost(
+  origin: string,
+  path: string,
+  host: string,
+  authorization: string,
+): Promise<{ status: number; body: string }> {
+  const url = new URL(path, origin);
+  return new Promise((resolve, reject) => {
+    const request = httpRequest({
+      hostname: url.hostname,
+      port: url.port,
+      path: url.pathname,
+      method: 'GET',
+      headers: { Host: host, Authorization: authorization },
+    }, (response) => {
+      const chunks: Buffer[] = [];
+      response.on('data', (chunk) => chunks.push(Buffer.from(chunk)));
+      response.on('end', () => resolve({
+        status: response.statusCode || 0,
+        body: Buffer.concat(chunks).toString('utf8'),
+      }));
+    });
+    request.on('error', reject);
+    request.end();
+  });
+}
+
+describe('CLI bridge server security and routing', () => {
+  it('generates high-entropy tokens and requires exact bearer authentication', () => {
+    const generated = generateBridgeToken();
+    expect(generated).toMatch(/^[A-Za-z0-9_-]{43}$/);
+    expect(Buffer.from(generated, 'base64url')).toHaveLength(32);
+    expect(isAuthorized(`Bearer ${token}`, token)).toBe(true);
+    expect(isAuthorized(`bearer ${token}`, token)).toBe(false);
+    expect(isAuthorized(`Bearer ${token}x`, token)).toBe(false);
+    expect(isAuthorized(undefined, token)).toBe(false);
+  });
+
+  it('exposes only health without authentication and sets defensive headers', async () => {
+    const handle = await startCliBridgeServer({
+      token,
+      bridgeVersion: '3.1.0',
+      registry: createAnalysisProviderRegistry([codexAdapter()]),
+      port: 0,
+    });
+    try {
+      const health = await fetch(`${handle.origin}/v1/health`);
+      expect(health.status).toBe(200);
+      expect(health.headers.get('cache-control')).toBe('no-store');
+      expect(health.headers.get('access-control-allow-origin')).toBeNull();
+      expect(await health.json()).toEqual({
+        bridgeVersion: '3.1.0',
+        protocolVersion: 1,
+        pairingConfigured: true,
+      });
+
+      const providers = await fetch(`${handle.origin}/v1/providers`);
+      expect(providers.status).toBe(401);
+      expect(await providers.json()).toEqual({
+        error: {
+          code: 'AUTH_REQUIRED',
+          message: 'Bridge authentication is required.',
+        },
+      });
+    } finally {
+      await handle.close();
+    }
+  });
+
+  it('rejects DNS-rebinding hosts, unsupported providers, paths, and methods', async () => {
+    const handle = await startCliBridgeServer({
+      token,
+      bridgeVersion: '3.1.0',
+      registry: createAnalysisProviderRegistry([codexAdapter()]),
+      port: 0,
+    });
+    const auth = { Authorization: `Bearer ${token}` };
+    try {
+      const badHost = await requestWithHost(
+        handle.origin,
+        '/v1/providers',
+        'attacker.example',
+        `Bearer ${token}`,
+      );
+      expect(badHost.status).toBe(400);
+      expect(badHost.body).not.toContain('attacker.example');
+
+      const unsupported = await fetch(`${handle.origin}/v1/providers/ollama/models`, {
+        headers: auth,
+      });
+      expect(unsupported.status).toBe(400);
+      expect(await unsupported.json()).toMatchObject({
+        error: { code: 'PROVIDER_UNSUPPORTED' },
+      });
+
+      const missing = await fetch(`${handle.origin}/v1/secret`, { headers: auth });
+      expect(missing.status).toBe(404);
+      expect(await missing.json()).toMatchObject({ error: { code: 'NOT_FOUND' } });
+
+      const method = await fetch(`${handle.origin}/v1/health`, { method: 'POST' });
+      expect(method.status).toBe(405);
+      expect(await method.json()).toMatchObject({ error: { code: 'METHOD_NOT_ALLOWED' } });
+    } finally {
+      await handle.close();
+    }
+  });
+
+  it('discovers providers, forces one provider test, and lists models', async () => {
+    const adapter = codexAdapter();
+    const handle = await startCliBridgeServer({
+      token,
+      bridgeVersion: '3.1.0',
+      registry: createAnalysisProviderRegistry([adapter]),
+      port: 0,
+    });
+    const headers = { Authorization: `Bearer ${token}` };
+    try {
+      const providers = await fetch(`${handle.origin}/v1/providers?force=true`, { headers });
+      expect(providers.status).toBe(200);
+      expect(await providers.json()).toMatchObject({
+        protocolVersion: 1,
+        providers: [{ id: 'codex-cli', ready: true }],
+      });
+
+      const tested = await fetch(`${handle.origin}/v1/providers/codex-cli/test`, {
+        method: 'POST',
+        headers,
+      });
+      expect(tested.status).toBe(200);
+      expect(await tested.json()).toMatchObject({ id: 'codex-cli', ready: true });
+
+      const models = await fetch(`${handle.origin}/v1/providers/codex-cli/models`, { headers });
+      expect(models.status).toBe(200);
+      expect(await models.json()).toEqual({
+        protocolVersion: 1,
+        models: [{ id: '', name: 'Codex default', source: 'default' }],
+      });
+      expect(adapter.discover).toHaveBeenCalledWith(true);
+    } finally {
+      await handle.close();
+    }
+  });
+});

--- a/tests/unit/cliBridgeSetup.test.ts
+++ b/tests/unit/cliBridgeSetup.test.ts
@@ -7,7 +7,7 @@ import {
 describe('CLI bridge setup presentation', () => {
   it('provides deterministic install, start, and token commands', () => {
     expect(CLI_BRIDGE_SETUP_COMMANDS).toEqual([
-      'npm install -g markuprx@latest',
+      'npm install -g https://github.com/hashfunction/MarkuprPlus/releases/download/v3.1.0/markuprx-3.1.0.tgz',
       'markuprx bridge install',
       'markuprx bridge token',
     ]);

--- a/tests/unit/cliBridgeSetup.test.ts
+++ b/tests/unit/cliBridgeSetup.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+import {
+  CLI_BRIDGE_SETUP_COMMANDS,
+  getCliBridgeStatusPresentation,
+} from '../../src/renderer/components/settings/CliBridgeSetup';
+
+describe('CLI bridge setup presentation', () => {
+  it('provides deterministic install, start, and token commands', () => {
+    expect(CLI_BRIDGE_SETUP_COMMANDS).toEqual([
+      'npm install -g markuprx@latest',
+      'markuprx bridge install',
+      'markuprx bridge token',
+    ]);
+  });
+
+  it('presents connected state without including secret material', () => {
+    expect(getCliBridgeStatusPresentation({
+      state: 'connected',
+      paired: true,
+      providers: [{
+        id: 'codex-cli',
+        name: 'Codex CLI',
+        installed: true,
+        authenticated: true,
+        ready: true,
+      }],
+    })).toEqual({
+      label: 'Connected',
+      detail: '1 of 1 CLI providers ready',
+      tone: 'success',
+    });
+  });
+
+  it('keeps offline, incompatible, and not-paired states actionable', () => {
+    expect(getCliBridgeStatusPresentation({
+      state: 'offline',
+      paired: true,
+      diagnostic: 'Start MarkuprPlus CLI Bridge.',
+    })).toEqual({
+      label: 'Bridge offline',
+      detail: 'Start MarkuprPlus CLI Bridge.',
+      tone: 'warning',
+    });
+    expect(getCliBridgeStatusPresentation({
+      state: 'incompatible',
+      paired: true,
+      diagnostic: 'Update MarkuprPlus CLI Bridge.',
+    }).label).toBe('Update required');
+    expect(getCliBridgeStatusPresentation(null).label).toBe('Checking bridge…');
+  });
+});

--- a/tests/unit/publicPackageVerification.test.ts
+++ b/tests/unit/publicPackageVerification.test.ts
@@ -430,12 +430,12 @@ describe('public package verification', () => {
   });
 
   it.each([
-    'markuprplus-3.0.0-arm64.dmg',
-    'MarkuprPlus-3.0.0-arm64-mac.zip',
-    'markuprplus-Setup-3.0.0.exe',
-    'MarkuprPlus 3.0.0.exe',
-    'markuprplus-3.0.0-x86_64.AppImage',
-    'markuprplus-3.0.0-amd64.deb',
+    'markuprplus-3.1.0-arm64.dmg',
+    'MarkuprPlus-3.1.0-arm64-mac.zip',
+    'markuprplus-Setup-3.1.0.exe',
+    'MarkuprPlus 3.1.0.exe',
+    'markuprplus-3.1.0-x86_64.AppImage',
+    'markuprplus-3.1.0-amd64.deb',
   ])('accepts the canonical filename contract before runtime verification: %s', (name) => {
     const root = fixture();
     writeFileSync(join(root, name), 'fixture');


### PR DESCRIPTION
## Summary
- restore Codex, Claude Code, OpenCode, Cursor Agent, Qwen Code, Goose, Amp, Kiro, and Aider setup in the sandboxed Mac App Store UI
- route Store CLI analysis through a separately installed, authenticated loopback companion without executing shell commands in the Store sandbox
- add Keychain pairing, provider diagnostics, strict request limits, Store metadata/review notes, and signed-package upload automation
- bump MarkuprPlus to 3.1.0 (Mac App Store build 3)

## Verification
- 1,889 unit/integration tests pass
- 44/44 Electron Playwright tests pass
- lint (0 errors; 7 existing warnings), typecheck, brand audit, and CI audit pass
- direct and Mac App Store universal builds pass
- signed Store package verified for bundle com.eddiesanjuan.markuprx, version 3.1.0, build 3
- live authenticated bridge smoke test passed with Codex and Claude detected
- compiled Codex bridge analysis returned a structured report

## Store delivery
The exact signed package is checksum-pinned in a private draft release and will be validated/uploaded by the App Store workflow after merge.