### PR TITLE
Fix macOS release notarization handoff

### DIFF
--- a/.github/workflows/app-store-upload.yml
+++ b/.github/workflows/app-store-upload.yml
@@ -91,7 +91,7 @@ jobs:
           set -euo pipefail
           xcrun altool --list-providers \
             --username "$APPLE_ID" \
-            --password @env:APPLE_APP_SPECIFIC_PASSWORD \
+            --app-password "$APPLE_APP_SPECIFIC_PASSWORD" \
             --output-format json > "$RUNNER_TEMP/providers.json"
 
           node <<'NODE'
@@ -128,7 +128,7 @@ jobs:
           set -euo pipefail
           xcrun altool --validate-app "$PACKAGE_PATH" \
             --username "$APPLE_ID" \
-            --password @env:APPLE_APP_SPECIFIC_PASSWORD \
+            --app-password "$APPLE_APP_SPECIFIC_PASSWORD" \
             --provider-public-id "$PROVIDER_PUBLIC_ID" \
             --output-format json
 
@@ -140,7 +140,7 @@ jobs:
           set -euo pipefail
           xcrun altool --upload-package "$PACKAGE_PATH" \
             --username "$APPLE_ID" \
-            --password @env:APPLE_APP_SPECIFIC_PASSWORD \
+            --app-password "$APPLE_APP_SPECIFIC_PASSWORD" \
             --provider-public-id "$PROVIDER_PUBLIC_ID" \
             --wait \
             --output-format json | tee "$RUNNER_TEMP/upload-result.json"

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -49,6 +49,10 @@ mac:
   icon: build/icon.icns
   hardenedRuntime: true
   gatekeeperAssess: false
+  # scripts/notarize.cjs is the single notarization path. Disabling
+  # electron-builder's built-in pass prevents it from consuming the same
+  # credentials before the afterSign hook runs.
+  notarize: false
   entitlements: build/entitlements.mac.plist
   entitlementsInherit: build/entitlements.mac.inherit.plist
   # Hide from dock and Cmd+Tab - pure menu bar app

--- a/tests/unit/publicPackagingMetadata.test.ts
+++ b/tests/unit/publicPackagingMetadata.test.ts
@@ -36,6 +36,10 @@ describe('public packaging identity', () => {
       appId: 'com.eddiesanjuan.markuprx',
       productName: 'MarkuprPlus',
       executableName: 'MarkuprPlus',
+      afterSign: 'scripts/notarize.cjs',
+      mac: {
+        notarize: false,
+      },
       extraResources: [
         {
           from: 'assets',


### PR DESCRIPTION
## Summary
- pass app-specific passwords through altool’s dedicated authentication option
- disable electron-builder’s duplicate built-in notarization pass
- keep `scripts/notarize.cjs` as the single fail-closed app notarization and stapling hook

## Evidence
The v3.1.0 release runner signed the app successfully, then electron-builder crashed in its own built-in notifier before the custom `afterSign` hook. The configuration now explicitly skips that duplicate pass. Targeted packaging tests (44/44), workflow audit, and lint pass locally.